### PR TITLE
Update GitHub urls referenced in ARM templates with the raw.githubusercontent.com ones

### DIFF
--- a/tools/deployment/azureDeployMainTemplate.json
+++ b/tools/deployment/azureDeployMainTemplate.json
@@ -93,7 +93,7 @@
     "variables": {
         "vnetName": "[concat(parameters('clusterName'),'-vnet')]",
         "subnetName": "subnet1",
-        "templateBaseUrl": "https://github.com/Azure/mmlspark/blob/master/tools/deployment/",
+        "templateBaseUrl": "https://raw.githubusercontent.com/Azure/mmlspark/master/tools/deployment/",
         "sparkClusterTemplateUrl": "[concat(variables('templateBaseUrl'), 'sparkClusterInVnetTemplate.json')]",
         "vmTemplateUrl": "[concat(variables('templateBaseUrl'), 'gpuVmExistingVNetTemplate.json')]",
         "sparkClusterDeploymentName": "sparkClusterTemplate",

--- a/tools/deployment/gpuVmExistingVNetTemplate.json
+++ b/tools/deployment/gpuVmExistingVNetTemplate.json
@@ -127,7 +127,7 @@
                         "autoUpgradeMinorVersion": true,
                         "settings": {
                             "fileUris": [
-                                "https://github.com/Azure/mmlspark/blob/master/tools/deployment/gpuvmsetup.sh"
+                                "https://raw.githubusercontent.com/Azure/mmlspark/master/tools/deployment/gpuvmsetup.sh"
                             ],
                             "commandToExecute": "sh gpuvmsetup.sh"
                         }


### PR DESCRIPTION
Azure can only works with the "raw.githubusercontent.com" links to GitHub items referenced in an ARM template. For example,
 https://github.com/Azure/azuremls/blob/master/tools/deployment/sparkClusterInVnetTemplate.json 
needs to be changed to
 https://raw.githubusercontent.com/Azure/mmlspark/master/tools/deployment/sparkClusterInVnetTemplate.json
