### PR TITLE
Re-enable the docker EULA server

### DIFF
--- a/tools/docker/bin/launcher
+++ b/tools/docker/bin/launcher
@@ -9,16 +9,18 @@ cd "$HOME/notebooks"
 echo "spark.sql.warehouse.dir $HOME/spark-warehouse" \
      > "$HOME/lib/spark/conf/spark-defaults.conf"
 
+port="${MMLSPARK_JUPYTER_PORT:=8888}"
+
 if [[ "${ACCEPT_EULA,,}" != @(y|yes) ]]; then
-  { echo "ERROR: You must accept the End User License Agreement to use this container."
-    echo "Run this container with \"eula\" to read the EULA."
-    echo "Set the environment variable ACCEPT_EULA to \"Yes\" (or \"Y\") to accept the"
-    echo "agreement, e.g., \"docker run -it -e ACCEPT_EULA=Y ...\"."
-  } 1>&2
-  exit 1
-  echo "Waiting for EULA agreement"; eula.py || exit 1
+  echo "You must accept the End User License Agreement to use this container,"
+  echo "go to http://localhost:$port/ to read it and accept."
+  echo ""
+  echo "Alternatively, set the environment variable ACCEPT_EULA to \"Yes\" (or \"Y\")"
+  echo "to accept the agreement, e.g., \"docker run -it -e ACCEPT_EULA=Y ...\"."
+  echo ""
+  echo "Waiting for EULA agreement at http://localhost:$port/"; eula.py || exit 1
 fi
 
 PYSPARK_DRIVER_PYTHON="jupyter" \
-PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser --port=${MMLSPARK_JUPYTER_PORT:=8888} --ip=*" \
+PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser --port=$port --ip=*" \
   pyspark --master "local[*]" --repositories "$MML_M2REPOS" --packages "$MML_PACKAGE"


### PR DESCRIPTION
Keep some of the error message, so people can skip it early, or in case
launching the python web server fails for whatever reason.

Use `microsoft/mmlspark:0.4.5` to try it out.