### PR TITLE
Documentation corrections and updates

### DIFF
--- a/src/codegen/src/main/scala/WrapperClassDoc.scala
+++ b/src/codegen/src/main/scala/WrapperClassDoc.scala
@@ -22,14 +22,14 @@ object WrapperClassDoc {
     className match {
       case "AssembleFeatures" =>
         s"""Assembles feature columns into a vector column of features
-           |
            |""".stripMargin
-      case "CNTKLearner" =>
+      case "CNTKLearner.txt" =>
         s"""``CNTKLearner`` trains a model on a dataset on a GPU edge node. The result is a ``CNTKModel``.
-           |
            |""".stripMargin
       case "CNTKModel" =>
-        s"""The ``CNTKModel`` evaluates a pre-trained CNTK model in parallel. The ``CNTKModel``
+        s"""Evaluate a CNTK Model.
+           |
+           |    The ``CNTKModel`` evaluates a pre-trained CNTK model in parallel. The ``CNTKModel``
            |    takes a path to a model and automatically loads and distributes the model to workers
            |    for parallel evaluation using CNTK's java bindings.
            |
@@ -40,62 +40,57 @@ object WrapperClassDoc {
            |    The ``CNTKModel`` takes an input column which should be a column of spark vectors and returns
            |    a column of spark vectors representing the activations of the selected node. By default, the CNTK model
            |    defaults to using the model's first input and first output node.
-           |
            |""".stripMargin
       case "CheckpointData" =>
-        s"""``CheckpointData`` persista data to disk as well as memory.
+        s"""``CheckpointData`` persists data to disk as well as memory.
            |
            |    Storage level is MEMORY_AND_DISK if true, else MEMORY_ONLY.
            |    Default is false (MEMORY_ONLY)
            |
            |    Use the removeCheckpoint parameter to reverse the cache operation.
-           |
            |""".stripMargin
       case "ComputeModelStatistics" =>
         s"""``ComputeModelStatistics`` returns the specified statistics on all the models specified
            |
            |    The possible metrics are:\n
-           |    Binary Classifiers:\n
-           |    - \"AreaUnderROC\"\n
-           |    - \"AUC\"\n
-           |    - \"accuracy\"\n
-           |    - \"recall\"\n
-           |    - \"all\"\n
-           |    Regression Classifiers:\n
-           |    - \"mse\"\n
-           |    - \"rmse\"\n
-           |    - \"r2\"\n
-           |    - \"all\"\n
-           |
+           |    Binary Classifiers:
+           |    - \"AreaUnderROC\"
+           |    - \"AUC\"
+           |    - \"accuracy\"
+           |    - \"recall\"
+           |    - \"all\"
+           |    Regression Classifiers:
+           |    - \"mse\"
+           |    - \"rmse\"
+           |    - \"r2\"
+           |    - \"all\"
            |""".stripMargin
 
       case "ComputePerInstanceStatistics" =>
         s"""Evaluates the given scored dataset with per instance metrics.
            |
            |    The Regression metrics are:\n
-           |    - \"L1_loss\"\n
-           |    - \"L2_loss\"\n
+           |    - \"L1_loss\"
+           |    - \"L2_loss\"
            |
            |    The Classification metrics are:
-           |    - \"log_loss\"\n
-           |
+           |    - \"log_loss\"
            |""".stripMargin
       case "DataConversion" =>
         s"""Converts the specified list of coluns to the specified type. The types are specified by
            |    the following strings:\n
-           |    - \"boolean\"\n
-           |    - \"byte\"\n
-           |    - \"short\"\n
-           |    - \"omteger\"\n
-           |    - \"long\"\n
-           |    - \"float\"\n
-           |    - \"double\"\n
-           |    - \"string\"\n
-           |    - \"toCategorical\" - make the column be a categorical column\n
-           |    - \"clearCategorical\" - clear the categorical column\n
-           |    - \"date\" - the default date format is: \"yyyy-MM-dd HH:mm:ss\"\n
-           |
-         """.stripMargin
+           |    - \"boolean\"
+           |    - \"byte\"
+           |    - \"short\"
+           |    - \"integer\"
+           |    - \"long\"
+           |    - \"float\"
+           |    - \"double\"
+           |    - \"string\"
+           |    - \"toCategorical\" - make the column be a categorical column
+           |    - \"clearCategorical\" - clear the categorical column
+           |    - \"date\" - the default date format is: \"yyyy-MM-dd HH:mm:ss\"
+           |""".stripMargin
       case "FastVectorAssembler" =>
         s"""A fast vector assembler. The columns given must be ordered such that categorical columns come first.
            |    Otherwise, Spark learners will give categorical attributes to the wrong index. The assembler
@@ -103,15 +98,12 @@ object WrapperClassDoc {
            |    are millions of columns.
            |
            |    To use this ``FastVectorAssemble`` you must import the org.apache.spark.ml.feature package.
-           |
            |""".stripMargin
       case "Featurize" =>
         s"""Featurizes a dataset. Converts the specified columns to feature columns.
-           |
            |""".stripMargin
       case "FindBestModel" =>
         s"""Evaluates and chooses the best model from a list of models
-           |
            |""".stripMargin
       case "ImageFeaturizer" =>
         s"""The ``ImageFeaturizer`` relies on a ``CNTKModel`` to do the featurization of the image(s). One can
@@ -127,7 +119,6 @@ object WrapperClassDoc {
            |    many layers to truncate from the output of the network. For example, layer=0 means that no layers
            |    are removed, layer=2 means that the image featurizer returns the activations of the layer that is
            |    two layers from the output layer, and so on.
-           |
            |""".stripMargin
       case "ImageReader" => ""
       case "ImageTransform" => ""
@@ -138,36 +129,32 @@ object WrapperClassDoc {
            |    tranformations.
            |
            |    Examples can be found in the sample notebook,
-           |
            |""".stripMargin
       case "MultiColumnAdapter" =>
         s"""Takes a unary transformer and a list of input output column pairs
            |    and applies the transformer to each column
-           |
            |""".stripMargin
       case "PartitionSample" =>
         s"""Sampling mode. The options are:\n
-           |    - AssignToPartition\n
-           |    - RandomSample\n
-           |    - Head\n
+           |        - AssignToPartition
+           |        - RandomSample
+           |        - Head\n
            |    The default is RandomSample.
            |
-           |    Relevant paramters for the different modes are:\n
+           |    Relevant parameters for the different modes are:\n
            |    - When the mode is AssignToPartition:\n
-           |        - seed - the seed for random partition assignment\n
+           |        - seed - the seed for random partition assignment
            |        - numParts - the number of partitions. Default is 10
            |        - newColName - the name of the partition column. Default is \"Partition\"\n
            |    - When the mode is RandomSample:\n
-           |        - mode - Absolute or Percentage\n
-           |        - count - the number of rows to assign to each partition when Absolute\n
+           |        - mode - Absolute or Percentage
+           |        - count - the number of rows to assign to each partition when Absolute
            |        - percent - the percentage per partition when Percentage\n
            |    - When the mode is Head:\n
-           |        - count - the number of rows\n
-           |
+           |        - count - the number of rows
            |""".stripMargin
       case "Repartition" =>
         s"""Partitions the dataset into n partitions. Default value for n is 10.
-           |
            |""".stripMargin
       case "SelectColumns" =>
         s"""``SelectColumns`` takes a list of column names and returns a DataFrame consisting of only those columns.
@@ -188,37 +175,36 @@ object WrapperClassDoc {
             |    >>> data2 = SelectColumns(cols = [\"col1\", \"col2\"]).transform(data)
             |    >>> data2.columns
             |    ['col1', 'col2']
-            |
-            |
             |""".stripMargin
       case "SummarizeData" =>
-        s"""Compute summary statistics for the dataset. Statistics to be computed:\n
-           |    - counts\n
-           |    - basic\n
-           |    - sample\n
-           |    - percentiles\n
+        s"""Compute summary statistics for the dataset.
+           |
+           |    Statistics to be computed:
+           |
+           |        - counts
+           |        - basic
+           |        - sample
+           |        - percentiles
            |
            |    errorThreshold (default 0.0) is the error threshold for quantiles.
-           |
            |""".stripMargin
       case "TextFeaturizer" =>
         s"""Featurize text.
            |
            |    The default output column name is \"<uid>__output\"
-           |
            |""".stripMargin
       case "TrainClassifier" =>
         s"""Trains a classifier model
             |
             |    The currently supported models and the names to be provided in the \"model\"
-            |    parameter are:\n
-            |    - Logistic Regression - \"LogisticRegression\"\n
-            |    - Decision Tree - \"DecisionTreeClassification\"\n
-            |    - Random Forest - \"RandomForestClassification\"\n
-            |    - Gradient Boosted Trees - \"GradientBoostedTreesClassification\"\n
-            |    - Naive Bayes - \"NaiveBayesClassifier\"\n
-            |    - Multilayer Perceptron - \"MultilayerPerceptronClassifier\"\n
+            |    parameter are:
             |
+            |    - Logistic Regression - \"LogisticRegression\"
+            |    - Decision Tree - \"DecisionTreeClassification\"
+            |    - Random Forest - \"RandomForestClassification\"
+            |    - Gradient Boosted Trees - \"GradientBoostedTreesClassification\"
+            |    - Naive Bayes - \"NaiveBayesClassifier\"
+            |    - Multilayer Perceptron - \"MultilayerPerceptronClassifier\"
             |""".stripMargin
       case "TrainRegressor" =>
         s"""Use ``TrainRegressor`` to train a regression model on a dataset.
@@ -242,9 +228,17 @@ object WrapperClassDoc {
         s"""Converts the representation of an m X n pixel image to an m * n vector of double.
            |
            |    The input column name is assumed to be \"image\", the output column name is \"<uid>_output\"
-           |
            |""".stripMargin
       case "Utils" =>""
+      case "ValueIndexer" =>
+        s"""Fits a dictionary of values from the input column.
+           |
+           |    The ``ValueIndexer`` generates a model, then transforms a column
+           |    to a categorical column of the given array of values. It is similar
+           |    to ``StringIndexer`` except that it can be used on any value types.
+           |""".stripMargin
+      case "ValueIndexerModel" =>
+        s"""Model produced by ValueIndexer"""
       case "__init__" =>
         s""""\""
            |MicrosoftML is a library of Python classes to interface with the Microsoft scala APIs to

--- a/src/core/contracts/src/main/scala/Params.scala
+++ b/src/core/contracts/src/main/scala/Params.scala
@@ -110,37 +110,67 @@ trait Wrappable extends Params {
 }
 
 trait HasInputCol extends Wrappable {
+  /** The name of the input column
+    * @group param
+    */
   val inputCol = StringParam(this, "inputCol", "The name of the input column")
+  /** @group setParam */
   def setInputCol(value: String): this.type = set(inputCol, value)
+  /** @group getParam */
   def getInputCol: String = $(inputCol)
 }
 
 trait HasOutputCol extends Wrappable {
+  /** The name of the output column
+    * @group param
+    */
   val outputCol = StringParam(this, "outputCol", "The name of the output column")
+  /** @group setParam */
   def setOutputCol(value: String): this.type = set(outputCol, value)
+  /** @group getParam */
   def getOutputCol: String = $(outputCol)
 }
 
 trait HasInputCols extends Wrappable {
+  /** The names of the inputColumns
+    * @group param
+    */
   val inputCols = new StringArrayParam(this, "inputCols", "The names of the input columns")
+  /** @group setParam */
   def setInputCols(value: Array[String]): this.type = set(inputCols, value)
+  /** @group getParam */
   def getInputCols: Array[String] = $(inputCols)
 }
 
 trait HasOutputCols extends Wrappable {
+  /** The names of the output columns
+    * @group param
+    */
   val outputCols = new StringArrayParam(this, "outputCols", "The names of the output columns")
+  /** @group setParam */
   def setOutputCols(value: Array[String]): this.type = set(outputCols, value)
+  /** @group getParam */
   def getOutputCols: Array[String] = $(outputCols)
 }
 
 trait HasLabelCol extends Wrappable {
+  /** The name of the label column
+    * @group param
+    */
   val labelCol = StringParam(this, "labelCol", "The name of the label column")
+  /** @group setParam */
   def setLabelCol(value: String): this.type = set(labelCol, value)
+  /** @group getParam */
   def getLabelCol: String = $(labelCol)
 }
 
 trait HasFeaturesCol extends Wrappable {
+  /** The name of the features column
+    * @group param
+    */
   val featuresCol = StringParam(this, "featuresCol", "The name of the features column")
+  /** @group setParam */
   def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+  /** @group getParam */
   def getFeaturesCol: String = $(featuresCol)
 }

--- a/src/core/schema/src/main/python/TypeConversionUtils.py
+++ b/src/core/schema/src/main/python/TypeConversionUtils.py
@@ -12,7 +12,6 @@ def generateTypeConverter(name, cache, typeConverter):
 
     Returns:
         lambda: Function to convert the type
-
     """
     return lambda value: typeConverter(name, value, cache)
 
@@ -27,7 +26,6 @@ def complexTypeConverter(name, value, cache):
 
     Returns:
         _java_obj:
-
     """
     cache[name]=value
     if isinstance(value, list):

--- a/src/core/schema/src/main/python/Utils.py
+++ b/src/core/schema/src/main/python/Utils.py
@@ -21,7 +21,7 @@ def from_java(java_stage, stage_name):
         stage_name (str):
 
     Returns:
-
+        object: The python wrapper
     """
     def __get_class(clazz):
         """
@@ -32,7 +32,6 @@ def from_java(java_stage, stage_name):
 
         Returns:
             object: The python object
-
         """
         parts = clazz.split(".")
         module = ".".join(parts[:-1])

--- a/src/downloader/src/main/python/ModelDownloader.py
+++ b/src/downloader/src/main/python/ModelDownloader.py
@@ -26,7 +26,6 @@ class ModelSchema:
         inputNode (int): the node which represents the input
         numLayers (int): the number of layers of the model
         layerNames (array): the names of nodes that represent layers in the network
-
     """
 
     def __init__(self, name, dataset, modelType, uri, hash, size, inputNode, numLayers, layerNames):
@@ -71,7 +70,6 @@ class ModelDownloader:
         sparkSession (SparkSession): A spark session for interfacing between python and java
         localPath (str): The folder to save models to
         serverURL (str): The location of the model Server, beware this default can change!
-
     """
 
     def __init__(self, sparkSession, localPath, serverURL=DEFAULT_URL):
@@ -88,55 +86,47 @@ class ModelDownloader:
 
     def localModels(self):
         """
-
         Downloads models stored locally on the filesystem
-
         """
         return self._wrap(self._model_downloader.localModels())
 
     def remoteModels(self):
         """
-
         Downloads models stored remotely.
-
         """
         return self._wrap(self._model_downloader.remoteModels())
 
     def downloadModel(self, model):
         """
-
         Download a model
-            model (object):
+
+        Args:
+            model (object): The model to be downloaded
 
         Returns:
             object: model schema
-
         """
         model = model.toJava(self._sparkSession)
         return ModelSchema.fromJava(self._model_downloader.downloadModel(model))
 
     def downloadByName(self, name):
         """
-
         Downloads a named model
 
         Args:
             name (str): The name of the model
-
-         """
+        """
         return ModelSchema.fromJava(self._model_downloader.downloadByName(name))
 
     def downloadModels(self, models=None):
         """
-
         Download models
 
         Args:
-            models:
+            models: The models to be downloaded
 
         Returns:
             list: list of models downloaded
-            
         """
         if models is None:
             models = self.remoteModels()

--- a/src/readers/src/main/python/ImageReader.py
+++ b/src/readers/src/main/python/ImageReader.py
@@ -25,8 +25,7 @@ def readImages(sparkSession, path, recursive = False, sampleRatio = 1.0, inspect
         sampleRatio (double): Fraction of the images loaded
 
     Returns:
-    :    DataFrame: DataFrame with a single column of "images", see imageSchema for details
-
+        DataFrame: DataFrame with a single column of "images", see imageSchema for details
     """
     ctx = SparkContext.getOrCreate()
     reader = ctx._jvm.com.microsoft.ml.spark.ImageReader
@@ -47,7 +46,6 @@ def isImage(df, column):
 
     Returns:
         bool: True if the colum is an image column
-
     """
 
     jvm = SparkContext.getOrCreate()._jvm

--- a/src/value-indexer/src/main/scala/ValueIndexer.scala
+++ b/src/value-indexer/src/main/scala/ValueIndexer.scala
@@ -106,15 +106,27 @@ class ValueIndexerModel(val uid: String)
 
   def this() = this(Identifiable.randomUID("ValueIndexerModel"))
 
+  /** Levels in categorical array
+    * @group param
+    */
   val levels = new ArrayParam(this, "levels", "levels in categorical array")
+  /** @group getParam */
   def getLevels: Array[_] = $(levels)
+  /** @group setParam */
   def setLevels(value: Array[_]): this.type = set(levels, value)
   setDefault(levels -> Array())
 
+  /** The datatype of the levels as a jason string
+    * @group param
+    */
   val dataType = StringParam(this, "dataType", "the datatype of the levels as json string", "string")
+  /** @group getParam */
   def getDataTypeStr: String = if ($(dataType) == "string") DataTypes.StringType.json else $(dataType)
+  /** @group setParam */
   def setDataTypeStr(value: String): this.type = set(dataType, value)
+  /** @group getParam */
   def getDataType: DataType = if ($(dataType) == "string") DataTypes.StringType else DataType.fromJson($(dataType))
+  /** @group setParam */
   def setDataType(value: DataType): this.type = set(dataType, value.json)
 
   setDefault(inputCol -> "input", outputCol -> (uid + "_output"))
@@ -129,8 +141,8 @@ class ValueIndexerModel(val uid: String)
       .setInputCol(getInputCol)
       .setOutputCol(getOutputCol)
 
+  /** Transform the input column to categorical */
   override def transform(dataset: Dataset[_]): DataFrame = {
-    // Transform the input column to categorical
     getDataType match {
       case _: IntegerType => addCategoricalColumn[Int](dataset)
       case _: LongType => addCategoricalColumn[Long](dataset)


### PR DESCRIPTION
- Parameterized indentation in formatted string that had multiple
spaces (i.e. "        some text" became "${ScopeDepth}some text")
- removed unnecessary blank lines in custom python scripts
- added docstrings and scaladocs for ValueIndexer
- corrected typos