### PR TITLE
Improve `Build.md` and a few other things

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ MMLSpark can be conveniently installed on existing Spark clusters via the
 `--packages` option, examples:
 
     spark-shell --packages com.microsoft.ml.spark:mmlspark_2.11:0.5 \
-                --repositories=https://mmlspark.azureedge.net/maven
+                --repositories https://mmlspark.azureedge.net/maven
 
     pyspark --packages com.microsoft.ml.spark:mmlspark_2.11:0.5 \
-            --repositories=https://mmlspark.azureedge.net/maven
+            --repositories https://mmlspark.azureedge.net/maven
 
     spark-submit --packages com.microsoft.ml.spark:mmlspark_2.11:0.5 \
-                 --repositories=https://mmlspark.azureedge.net/maven \
+                 --repositories https://mmlspark.azureedge.net/maven \
                  MyApp.jar
 
 <img title="Script action submission" src="http://i.imgur.com/oQcS0R2.png" align="right" />

--- a/tools/build-pr/report
+++ b/tools/build-pr/report
@@ -29,10 +29,10 @@ if [[ "$BUILDPR" = "" ]]; then
   exit
 fi
 
-text="The build has ${AGENT_JOBSTATUS,,}."
+text="The build has ${AGENT_JOBSTATUS,,}."; more_text=""
 post_status "$state" "$text"
 delete_comment
 if [[ "$state" = "success" && -r "$BUILD_ARTIFACTS/Build.md" ]]; then
-  text+=$'\n\n'"$(< "$BUILD_ARTIFACTS/Build.md")"
+  more_text="$(< "$BUILD_ARTIFACTS/Build.md")"
 fi
-post_comment "$box! — $text"
+post_comment "$box! — $text" "$more_text"

--- a/tools/config.sh
+++ b/tools/config.sh
@@ -125,12 +125,12 @@ INSTALLATIONS=(
 # The value is normalized to hold comma-separated `+tag` or `-tag`, except for a
 # single `all`/`none` which don't get a sign prefix.  $PUBLISH similarly holds
 # the specification of things to publish.
-defvar -x TESTS   "default"
-defvar -x PUBLISH "default"
-if [[ "$TESTS" = "default" ]]; then
+defvar -x TESTS   ""
+defvar -x PUBLISH ""
+if [[ -z "$TESTS" ]]; then
   if [[ "$BUILDMODE" = "server" ]]; then TESTS="all"; else TESTS="+scala,-extended"; fi
 fi
-if [[ "$PUBLISH" = "default" ]]; then
+if [[ -z "$PUBLISH" ]]; then
   if [[ "$BUILDMODE" = "server" ]]; then PUBLISH="-demo,-docker"; else PUBLISH="none"; fi
 fi
 # Tag definitions for $TESTS


### PR DESCRIPTION
* Add items to `Build.md` when uploading the maven and pip packages,
  when publishing to the demo cluster, and when pushing a new docker
  image.

* Upload Build.md to the main buildartifacts container so the updated
  information with all of the above is easily available.

* Verify azure login before any publishing happens.

* Misc minor tweaks.