### PR TITLE
Remove copyrights footnotes, except from `README.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,3 @@ or new features, follow these steps:
 A good way to get started contributing is to look for issues with a "help
 wanted" label.  These are issues that we do want to fix, but don't have
 resources to work on currently.
-
-*Apache®, Apache Spark, and Spark® are either registered trademarks or
-trademarks of the Apache Software Foundation in the United States and/or other
-countries.*

--- a/docs/your-first-model.md
+++ b/docs/your-first-model.md
@@ -103,7 +103,3 @@ Next, view our other tutorials to learn how to
 * Use SparkML pipelines to build a more complex model
 * Use deep neural networks for image classification
 * Use text analytics for document classification
-
-*Apache®, Apache Spark, and Spark® are either registered trademarks or
-trademarks of the Apache Software Foundation in the United States and/or other
-countries.*


### PR DESCRIPTION
It looks very redundant to repeat it in every text... so I think that
it's fine to leave on in the toplevel `README.md`.