### PR TITLE
Docgen correction

### DIFF
--- a/src/codegen/src/main/scala/DocGen.scala
+++ b/src/codegen/src/main/scala/DocGen.scala
@@ -44,8 +44,8 @@ object DocGen {
 
     // Generate .rst file for each PySpark wrapper - for documentation generation
     allFiles(toZipDir, _.getName.endsWith(".py"))
-        .foreach{x => writeFile(new File(inDocDir, StringUtils.capitalize(x.getName.dropRight(3)) + ".rst"),
-          contentsString(StringUtils.capitalize(x.getName.dropRight(3))))
+        .foreach{x => writeFile(new File(inDocDir, x.getName.dropRight(3) + ".rst"),
+          contentsString(x.getName.dropRight(3)))
         }
   }
 


### PR DESCRIPTION
Class names are capitalized when the PySpark wrappers are generated.
Therefore, it is unnecessary to capitalize again when generating
.rst files for documentation from the python wrappers.