### PR TITLE
Clear the ivy cache of mmlspark when running a local build

### DIFF
--- a/tools/bin/mml-exec
+++ b/tools/bin/mml-exec
@@ -30,6 +30,17 @@ if [[ "$exe" == "jupyter-notebook" ]]; then
   exe="pyspark"; args=()
 fi
 
+if [[ "$MML_VERSION" = *".local"* ]]; then
+  # If we're running a locally built version, delete the cached versions in
+  # "$HOME/.ivy2".  This is a hack since it depends on this particular location.
+  # The reason that it's in this script instead of in the build script is that
+  # ideally we'd configure spark to disable caching of just mmlspark, and these
+  # kind of spark settings are done in this file.
+  ( cd "$HOME/.ivy2"; shopt -s globstar nullglob
+    # Note: use *$MML_VERSION* to avoid hard wiring specific paths
+    for f in **/*"$MML_VERSION"*; do rm -rf "$f"; done )
+fi
+
 MML_M2REPOS="file:$BUILD_ARTIFACTS/packages/m2,$MAVEN_URL"
 MML_PACKAGE="com.microsoft.ml.spark:mmlspark_$SCALA_VERSION:$MML_VERSION"
 


### PR DESCRIPTION
I couldn't find any way to configure spark to avoid caching mmlspark in
ivy2, so instead just look for all files with the version string and
clear them out.  Do this in `mml-exec` since this is where such a spark
configuration would normally go.

Also fix some leftover code that resulted in two ".local"s in the
version.