### PR TITLE
Fix the pip installation on a cluster

### DIFF
--- a/tools/hdi/install-mmlspark.sh
+++ b/tools/hdi/install-mmlspark.sh
@@ -71,14 +71,17 @@ echo "Updating the Livy configuration..."
 python "$tmp/update_livy.py" "/home/spark/.sparkmagic/config.json" "$MAVEN_PACKAGE"
 rm -rf "$tmp"
 
-/bin/su livy -c \
-  "spark-shell --packages \"$MAVEN_PACKAGE\" --repositories \"$MAVEN_URL\" < /dev/null"
-
 for env in "${CONDA_ENVS[@]}"; do
-  _anaconda_bin activate "$condaenv"
+  _anaconda_bin activate "$env"
+  # first uninstall it, since otherwise an existing "1.2.dev3+4" version makes
+  # pip consider "1.2.dev3" as "already satisfied"
+  pip uninstall -y "mmlspark"
   pip install "$PIP_PACKAGE"
   _anaconda_bin deactivate
 done
+
+/bin/su livy -c \
+  "spark-shell --packages \"$MAVEN_PACKAGE\" --repositories \"$MAVEN_URL\" < /dev/null"
 
 # Check whether script is running on headnode
 if [[ "$(get_primary_headnode)" != "$(hostname -f)" ]]; then


### PR DESCRIPTION
1. There was a build failure which we tracked down to a situation there
   was a build of "0.5.dev29+1.geccd8f6" followed by a build of
   "0.5.dev29" -- and in the second one, pip decided that "Requirement
   already satisfied" which meant that it was using the earlier version.
   To avoid that, explicitly uninstall "mmlspark" to always get rid of
   other versions.

2. While tracking that, we found another bug where `$condaenv` was used
   instead of `$env`.  This meant that we would always install (twice)
   to the environment last specified in `$condaenv` which happened to be
   `py35`, the one that is actually used in the E2E tests.

3. It shouldn't matter in general, but I also moved the pip installation
   to happen before the dummy spark job that installs the mmlspark
   package.