### PR TITLE
Remove our `delTree`

### DIFF
--- a/src/cntk-train/src/test/scala/ValidateCntkTrain.scala
+++ b/src/cntk-train/src/test/scala/ValidateCntkTrain.scala
@@ -3,12 +3,13 @@
 
 package com.microsoft.ml.spark
 
+import java.io.File
 import java.net.URI
 
 import org.apache.spark.ml.feature.{OneHotEncoder, StringIndexerModel}
 import com.microsoft.ml.spark.Readers.implicits._
-import FileUtilities._
 import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.apache.commons.io.FileUtils
 
 trait TestFileCleanup extends BeforeAndAfterEach {
   this: Suite =>
@@ -16,10 +17,7 @@ trait TestFileCleanup extends BeforeAndAfterEach {
   override def afterEach(): Unit = {
     try super.afterEach() // To be stackable, must call super.afterEach
     finally {
-      if (cleanupPath.exists) {
-        FileUtilities.delTree(cleanupPath)
-        ()
-      }
+      if (cleanupPath.exists) FileUtils.forceDelete(cleanupPath)
     }
   }
 }

--- a/src/codegen/src/main/scala/CodeGen.scala
+++ b/src/codegen/src/main/scala/CodeGen.scala
@@ -3,14 +3,15 @@
 
 package com.microsoft.ml.spark.codegen
 
-import com.microsoft.ml.spark.FileUtilities._
 import Config._
 import DocGen._
 import WrapperClassDoc._
 
 import scala.util.matching.Regex
 import java.util.regex.Pattern
+import com.microsoft.ml.spark.FileUtilities._
 import org.apache.commons.io.FilenameUtils._
+import org.apache.commons.io.FileUtils
 
 object CodeGen {
 
@@ -72,8 +73,8 @@ object CodeGen {
     writeFile(new File(toZipDir, "__init__.py"), packageHelp(importStrings))
     // package python zip file
     zipFolder(toZipDir, zipFile)
-    // leave the source files there so they will be included in the super-jar
-    // if (!delTree(toZipDir)) println(s"Error: could not delete $toZipDir")
+    // leave the source files, so they will be included in the super-jar
+    // FileUtils.forceDelete(toZipDir)
   }
 
   def main(args: Array[String]): Unit = {

--- a/src/core/env/src/main/scala/FileUtilities.scala
+++ b/src/core/env/src/main/scala/FileUtilities.scala
@@ -30,11 +30,6 @@ object FileUtilities {
     }
   }
 
-  def delTree(file: File): Boolean =
-    if (!file.exists) true
-    else { if (file.isDirectory) file.listFiles.forall(delTree)
-           file.delete }
-
   def allFiles(dir: File, pred: (File => Boolean) = null): Array[File] = {
     def loop(dir: File): Array[File] = {
       val (dirs, files) = dir.listFiles.sorted.partition(_.isDirectory)

--- a/src/downloader/src/test/scala/DownloaderSuite.scala
+++ b/src/downloader/src/test/scala/DownloaderSuite.scala
@@ -6,6 +6,7 @@ package com.microsoft.ml.spark
 import java.nio.file.Files
 import com.microsoft.ml.spark.FileUtilities.File
 import scala.collection.JavaConversions._
+import org.apache.commons.io.FileUtils
 
 class DownloaderSuite extends TestBase {
 
@@ -42,7 +43,7 @@ class DownloaderSuite extends TestBase {
   }
 
   override def afterAll(): Unit = {
-    FileUtilities.delTree(saveDir)
+    FileUtils.forceDelete(saveDir)
     super.afterAll()
   }
 

--- a/src/find-best-model/src/test/scala/VerifyFindBestModel.scala
+++ b/src/find-best-model/src/test/scala/VerifyFindBestModel.scala
@@ -3,11 +3,10 @@
 
 package com.microsoft.ml.spark
 
-import java.io.File
-
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.ml.{Estimator, Transformer}
 import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
+import org.apache.commons.io.FileUtils
 
 class VerifyFindBestModel extends EstimatorFuzzingTest {
 
@@ -53,11 +52,8 @@ class VerifyFindBestModel extends EstimatorFuzzingTest {
 
     val myModelName = "testEvalModel"
     bestModel.save(myModelName)
-    val dir = new File(myModelName)
-    // assert directory exists
-    assert(dir.exists())
-    // delete the file to cleanup
-    FileUtilities.delTree(dir)
+    // delete the file, errors if it doesn't exist
+    FileUtils.forceDelete(new java.io.File(myModelName))
   }
 
   test("Verify the best model metrics can be retrieved and are valid") {

--- a/src/fuzzing/src/test/scala/Fuzzing.scala
+++ b/src/fuzzing/src/test/scala/Fuzzing.scala
@@ -3,11 +3,11 @@
 
 package com.microsoft.ml.spark
 
-import FileUtilities.File
 import org.apache.spark.ml._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util.{MLReadable, MLWritable}
 import org.apache.spark.sql.DataFrame
+import org.apache.commons.io.FileUtils
 
 import scala.language.existentials
 import scala.util.Random
@@ -222,8 +222,7 @@ class Fuzzing extends TestBase {
             throwOrLog(e, w.getClass.getName + " encounters an error while saving/loading")
             None
         } finally {
-          FileUtilities.delTree(new File(path))
-          ()
+          FileUtils.forceDelete(new java.io.File(path))
         }
       case tr =>
         assertOrLog(false, tr.getClass.getName + " needs to extend MLWritable")

--- a/src/image-transformer/src/test/scala/ImageTransformerSuite.scala
+++ b/src/image-transformer/src/test/scala/ImageTransformerSuite.scala
@@ -13,9 +13,9 @@ import org.opencv.core.{Mat, MatOfByte}
 import org.opencv.imgcodecs.Imgcodecs
 import org.opencv.imgproc.Imgproc
 import org.apache.spark.sql.Row
-import com.microsoft.ml.spark.FileUtilities.File
 import com.microsoft.ml.spark.Readers.implicits._
 import org.apache.spark.sql.SaveMode
+import org.apache.commons.io.FileUtils
 
 class ImageTransformerSuite extends LinuxOnly {
 
@@ -64,8 +64,7 @@ class ImageTransformerSuite extends LinuxOnly {
       val images1 = session.sqlContext.read.parquet(filename)
       assert(images1.count() == images.count())
     } finally {
-      FileUtilities.delTree(new File(filename))
-      ()
+      FileUtils.forceDelete(new java.io.File(filename))
     }
   }
 

--- a/src/train-classifier/src/test/scala/VerifyTrainClassifier.scala
+++ b/src/train-classifier/src/test/scala/VerifyTrainClassifier.scala
@@ -14,6 +14,7 @@ import org.apache.spark.mllib.evaluation.{BinaryClassificationMetrics, Multiclas
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
+import org.apache.commons.io.FileUtils
 
 object ClassifierTestUtils {
 
@@ -147,8 +148,7 @@ class VerifyTrainClassifier extends EstimatorFuzzingTest {
       assert(verifyResult(transformedDataset, benchmarkDataset))
     } finally {
       // delete the file to cleanup
-      FileUtilities.delTree(dir)
-      ()
+      FileUtils.forceDelete(dir)
     }
   }
 

--- a/src/train-regressor/src/test/scala/VerifyTrainRegressor.scala
+++ b/src/train-regressor/src/test/scala/VerifyTrainRegressor.scala
@@ -9,6 +9,7 @@ import org.apache.spark.ml.Estimator
 import org.apache.spark.ml.regression.{LinearRegression, RandomForestRegressor}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
+import org.apache.commons.io.FileUtils
 
 /** Tests to validate the functionality of Train Regressor module. */
 class VerifyTrainRegressor extends EstimatorFuzzingTest {
@@ -94,8 +95,7 @@ class VerifyTrainRegressor extends EstimatorFuzzingTest {
       assert(verifyResult(transformedDataset, benchmarkDataset))
     } finally {
       // delete the file to cleanup
-      FileUtilities.delTree(dir)
-      ()
+      FileUtils.forceDelete(dir)
     }
   }
 


### PR DESCRIPTION
Instead, use `commons.io.FileUtils.forceDelete` which is similar except
that it throws an error if the given path does not exist.

Supersedes #53.
