### PR TITLE
Minor script fixes

### DIFF
--- a/tools/bin/mml-exec
+++ b/tools/bin/mml-exec
@@ -30,7 +30,7 @@ if [[ "$exe" == "jupyter-notebook" ]]; then
   exe="pyspark"; args=()
 fi
 
-if [[ "$MML_VERSION" = *".local"* ]]; then
+if [[ "$MML_VERSION" = *".local"* && -d "$HOME/.ivy2" ]]; then
   # If we're running a locally built version, delete the cached versions in
   # "$HOME/.ivy2".  This is a hack since it depends on this particular location.
   # The reason that it's in this script instead of in the build script is that

--- a/tools/runme/build.sh
+++ b/tools/runme/build.sh
@@ -211,7 +211,8 @@ _publish_to_dockerhub() {
   local auth user pswd
   __ docker logout > /dev/null
   auth="$(__ az keyvault secret show --vault-name mmlspark-keys --name dockerhub-auth)"
-  auth="${auth##*\"value\": \"}"; auth="${auth%%\"*}"; auth="$(base64 -d <<<"$auth")"
+  auth="${auth##*\"value\": \"}"; auth="${auth%%\"*}"; auth="${auth%\\n}"
+  auth="$(base64 -d <<<"$auth")"
   user="${auth%%:*}" pswd="${auth#*:}"
   ___ docker login -u "$user" -p "$pswd" > /dev/null
   unset user pass auth


### PR DESCRIPTION
1. Checking which tag `master` is on doesn't work with the VSTS builds
   since it doesn't update `master`.  Use `$branch` instead.

2. Avoid clearing the ivy cache if `$HOME/.ivy2` doesn't exist.

3. Remove a possible `\n` in the keyvault value.
