### PR TITLE
Updating CNTKLearner to work with latest gpu branch updated with latest master

### DIFF
--- a/src/cntk-train/src/main/scala/BrainscriptBuilder.scala
+++ b/src/cntk-train/src/main/scala/BrainscriptBuilder.scala
@@ -38,6 +38,10 @@ class BrainScriptBuilder {
   }
 
   def getModelPath: String = {
+    s"""file://$getLocalModelPath"""
+  }
+
+  def getLocalModelPath: String = {
     s"""$outDir/Models/$modelName"""
   }
 
@@ -87,7 +91,7 @@ class BrainScriptBuilder {
       "deviceId=\"auto\"",
       s"""rootDir="$rootDir" """,
       s"""outputDir="$outDir" """,
-      s"""modelPath="${getModelPath}" """)
+      s"""modelPath="${getLocalModelPath}" """)
     val commandReaders = commands.map(c => s"$c = [ ${toReaderConfig} ]")
 
     rootOverrides ++ commandReaders

--- a/src/cntk-train/src/main/scala/CommandBuilders.scala
+++ b/src/cntk-train/src/main/scala/CommandBuilders.scala
@@ -8,13 +8,12 @@ import java.net.URI
 import scala.collection.mutable.ListBuffer
 import scala.sys.process._
 
-import com.microsoft.ml.spark.schema._
 import FileUtilities._
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.slf4j.Logger
 
-import scala.sys.process._
+import StreamUtilities.using
 
 abstract class CNTKCommandBuilderBase(log: Logger) {
   val command: String
@@ -132,10 +131,8 @@ class MPICommandBuilder(log: Logger,
     val identityPath = new Path(identity)
     val outputPath = new Path(s"file:///${identityDir.getAbsolutePath}/identity")
     // Copy from wasb to local file
-    using(Seq(inputPath.getFileSystem(hadoopConf))) { fs =>
-      log.info(s"Copying from wasb: $inputPath to local: $identityPath")
-      fs(0).copyToLocalFile(inputPath, identityPath)
-      fs(0).setOwner(outputPath, System.getProperty("user.name"), null)
+    using(inputPath.getFileSystem(hadoopConf)) { fs =>
+      fs.copyToLocalFile(inputPath, identityPath)
     }.get
     var localDir = workingDir.toString.replaceFirst("file:/+", "/")
     val modelPath = new Path(localDir, new Path(outputDir, "Models")).toString

--- a/src/codegen/src/main/scala/PySparkWrapper.scala
+++ b/src/codegen/src/main/scala/PySparkWrapper.scala
@@ -200,6 +200,7 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
       case "StringParam" => "str"
       case "Param" => "str"
       case "StringArrayParam" => "list"
+      case "ByteArrayParam" => "list"
       case "MapArrayParam" => "dict"
       case _ => "object"
     }

--- a/src/core/serialize/src/main/scala/params/ByteArrayParam.scala
+++ b/src/core/serialize/src/main/scala/params/ByteArrayParam.scala
@@ -7,9 +7,9 @@ package org.apache.spark.ml.param
   * types but not ByteArray.
   */
 class ByteArrayParam(parent: Params, name: String, doc: String, isValid: Array[Byte] => Boolean)
-  extends ComplexParam[Array[Byte]](parent, name, doc, isValid) {
+    extends ComplexParam[Array[Byte]](parent, name, doc, isValid) {
 
-    def this(parent: Params, name: String, doc: String) =
-      this(parent, name, doc, ParamValidators.alwaysTrue)
+  def this(parent: Params, name: String, doc: String) =
+    this(parent, name, doc, ParamValidators.alwaysTrue)
 
-  }
+}


### PR DESCRIPTION
Updating CNTKLearner to work with latest gpu branch updated with latest master.
Removed setting owner, fixed ByteArrayParam transfer from java to python, fixed path to model.
Verified full end-to-end scenario.