### PR TITLE
Fix Pyspark Wrapper Generation

### DIFF
--- a/src/codegen/src/main/scala/CodeGen.scala
+++ b/src/codegen/src/main/scala/CodeGen.scala
@@ -42,7 +42,7 @@ object CodeGen {
   }
 
   def generateArtifacts(): Unit = {
-    println(s"""|Running registration with config:
+    println(s"""|Running code generation with config:
                 |  topDir:    $topDir
                 |  srcDir:    $srcDir
                 |  outputDir: $outputDir

--- a/src/codegen/src/main/scala/PySparkWrapper.scala
+++ b/src/codegen/src/main/scala/PySparkWrapper.scala
@@ -35,8 +35,9 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
     ""
   }
 
-  // Note: in the get/set with kwargs, there is an if/else that is due to the fact that since 2.1.1, kwargs is an
-  //       instance attribute. Once support for 2.1.0 is dropped, the else part of the if/else can be removed,
+  // Note: in the get/set with kwargs, there is an if/else that is due to the fact that since 2.1.1,
+  //   kwargs is an instance attribute.  Once support for 2.1.0 is dropped, the else part of the
+  //   if/else can be removed
   protected def classTemplate(importsString: String, inheritanceString: String,
                               classParamsString: String,
                               paramDefinitionsAndDefaultsString: String, paramGettersAndSettersString: String,
@@ -149,7 +150,8 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
         |    @staticmethod
         |    def _from_java(java_stage):
         |        module_name=${entryPointName}.__module__
-        |        module_name=module_name.rsplit(".", 1)[0] + ".${entryPointName}"
+        |        module_name=module_name.rsplit(".", 1)[0] + ".${
+      if (entryPointName.startsWith("_")) entryPointName.tail else entryPointName}"
         |        return from_java(java_stage, module_name)
         |""".stripMargin
   }
@@ -164,7 +166,8 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
 
   val psType: String
   private lazy val objectBaseClass: String = "Java" + psType
-  private lazy val autoInheritedClasses = Seq("JavaMLReadable", "JavaMLWritable", objectBaseClass)
+  private lazy val autoInheritedClasses =
+    Seq("ComplexParamsMixin", "JavaMLReadable", "JavaMLWritable", objectBaseClass)
   // Complex types are not easily recognized by Py4j. They need special processing.
   private lazy val complexTypes =  Set[String](
     "TransformerParam",
@@ -344,7 +347,7 @@ class SparkEstimatorWrapper(entryPoint: Estimator[_],
         |""".stripMargin
 
   private def modelClassString(className: String, superClass: String): String = {
-    s"""|class ${className}(JavaModel, JavaMLWritable, JavaMLReadable):
+    s"""|class ${className}(ComplexParamsMixin, JavaModel, JavaMLWritable, JavaMLReadable):
         |    "\""
         |    Model fitted by :class:`${superClass}`.
         |

--- a/src/core/schema/src/main/python/TypeConversionUtils.py
+++ b/src/core/schema/src/main/python/TypeConversionUtils.py
@@ -1,6 +1,8 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in project root for information.
 
+from py4j.protocol import Py4JError
+
 def generateTypeConverter(name, cache, typeConverter):
     """
     Type converter
@@ -28,16 +30,20 @@ def complexTypeConverter(name, value, cache):
         _java_obj:
     """
     cache[name]=value
-    if isinstance(value, list):
-        java_value=[]
-        for v in value:
-            if hasattr(v, "_transfer_params_to_java"):
-                v._transfer_params_to_java()
-            java_value.append(v._java_obj)
-        return java_value
-    if hasattr(value, "_transfer_params_to_java"):
-        value._transfer_params_to_java()
-    if hasattr(value, "_java_obj"):
-        return value._java_obj
-    else:
-        return value._to_java()
+    try:
+        if isinstance(value, list):
+            java_value=[]
+            for v in value:
+                if hasattr(v, "_transfer_params_to_java"):
+                    v._transfer_params_to_java()
+                java_value.append(v._java_obj)
+            return java_value
+        if hasattr(value, "_transfer_params_to_java"):
+            value._transfer_params_to_java()
+        if hasattr(value, "_java_obj"):
+            return value._java_obj
+        else:
+            return value._to_java()
+    except Py4JError as e:
+        return value
+


### PR DESCRIPTION
-fix a problem where internal wrappers could not be serialized
-fix a problem where byte array params were not transferred to python properly
