### PR TITLE
Performance improvement for BinaryFileReader and ImageReader

### DIFF
--- a/src/readers/src/main/scala/BinaryFileReader.scala
+++ b/src/readers/src/main/scala/BinaryFileReader.scala
@@ -40,6 +40,7 @@ object BinaryFileReader {
     var data: RDD[(String, Array[Byte])] = null
     try {
       val streams = spark.sparkContext.binaryFiles(path, spark.sparkContext.defaultParallelism)
+        .repartition(spark.sparkContext.defaultParallelism)
 
       // Create files RDD and load bytes
       data = if (!inspectZip) {


### PR DESCRIPTION
Performance improvement for BinaryFileReader and ImageReader.
Temporary fix around bug introduced in spark 2.1 (from spark 2.0).

Validated performance improvement on Mark's demo cluster (previously would not finish, afterwards would take a couple minutes/seconds for operations).