### PR TITLE
Resolve throttling issue

### DIFF
--- a/tools/misc/container-gc
+++ b/tools/misc/container-gc
@@ -26,11 +26,6 @@ GH_API="https://api.github.com/repos/Azure/mmlspark"
 github_prs="$(curl --silent --show-error "$GH_API/pulls" \
               | jq -r 'map(.number | tostring) | " " + join(" ") + " "')"
 
-export AZURE_STORAGE_ACCOUNT="$MAIN_STORAGE"
-export AZURE_STORAGE_KEY="$(
-  az storage account keys list -n "$MAIN_STORAGE" -g "$MAIN_RESOURCE_GROUP" | \
-    jq -r '.[0].value')"
-
 now=0; _minute=$((60)); _hour=$((60*60)); _day=$((_hour*24))
 show-time() (
   time="$1"

--- a/tools/pydocs/publish
+++ b/tools/pydocs/publish
@@ -102,7 +102,6 @@ for ((i=-1; i<len; i++)); do
     --container "$DOCS_CONTAINER" --content-type "text/html" \
     --file "$tmp" --name "$webdir" \
     2> /dev/null
-  sleep 5 # FIXME!! Remove this when throttling is resolved!
 done
 rm -f "$tmp"
 

--- a/tools/runme/build.sh
+++ b/tools/runme/build.sh
@@ -184,15 +184,14 @@ _publish_docs() {
     # there is no api for copying to a different path, so re-do the whole thing,
     # but first, delete any paths that are not included in the new contents
     local d f
-    # FIXME!!  Disabled deletion to avoid extra api calls, re-enable when throttling is resolved!
-    # for d in "scala" "pyspark"; do
-    #   __ azblob list --container-name "$DOCS_CONTAINER" --prefix "$d/" -o tsv | cut -f 3
-    # done | while read -r f; do
-    #   if [[ -e "$BUILD_ARTIFACTS/docs/$f" ]]; then continue; fi
-    #   echo -n "deleting $f..."
-    #   if collect_log=1 __ azblob delete --container-name "$DOCS_CONTAINER" -n "$f" > /dev/null
-    #   then echo " done"; else echo " failed"; failwith "deletion of $f failed"; fi
-    # done
+    for d in "scala" "pyspark"; do
+      __ azblob list --container-name "$DOCS_CONTAINER" --prefix "$d/" -o tsv | cut -f 3
+    done | while read -r f; do
+      if [[ -e "$BUILD_ARTIFACTS/docs/$f" ]]; then continue; fi
+      echo -n "deleting $f..."
+      if collect_log=1 __ azblob delete --container-name "$DOCS_CONTAINER" -n "$f" > /dev/null
+      then echo " done"; else echo " failed"; failwith "deletion of $f failed"; fi
+    done
     @ "../pydocs/publish" --top
     _add_to_description '* Also copied as [toplevel documentation](%s).\n' "$DOCS_URL"
   fi

--- a/tools/runme/runme.sh
+++ b/tools/runme/runme.sh
@@ -25,6 +25,17 @@ PATH="/usr/bin:/bin"
 [[ -r "$TOOLSDIR/local-config.sh" ]] && @ "$TOOLSDIR/local-config.sh"
 @ "../config.sh"; _post_config
 
+# arrange to set these lazily, when `az` is called
+az() {
+  unset -f az
+  export AZURE_STORAGE_ACCOUNT="$MAIN_STORAGE"
+  export AZURE_STORAGE_KEY="$(
+    x="$(az storage account keys list -n "$MAIN_STORAGE" -g "$MAIN_RESOURCE_GROUP" \
+            -o tsv | head -1)"
+    echo "${x##*$'\t'}")"
+  az "$@"
+}
+
 # main runme functionality
 _runme() {
   @ "install.sh"

--- a/tools/runme/utils.sh
+++ b/tools/runme/utils.sh
@@ -342,10 +342,10 @@ get_runtime_hash() {
 }
 
 # ---< azblob verb arg... >-----------------------------------------------------
-# Same as "az storage blob <verb> --account-name $MAIN_STORAGE arg..."
+# Same as "az storage blob <verb> arg..."
 azblob() {
   local verb="$1"; shift
-  az storage blob "$verb" --account-name "$MAIN_STORAGE" "$@"
+  az storage blob "$verb" "$@"
 }
 
 # ---< _curl arg... >-----------------------------------------------------------


### PR DESCRIPTION
Most (hopefully all) of our API throttling issues were a result of the
CLI retrieving the subscription information each time it starts.  This
can be avoided by retrieving it once and setting `$AZURE_STORAGE_KEY` to
it.

(Note that this is done lazily, when `az` is first used.)