### PR TITLE
Fix behavior of ImageReader for corrupt images

### DIFF
--- a/src/readers/src/main/scala/ImageReader.scala
+++ b/src/readers/src/main/scala/ImageReader.scala
@@ -6,7 +6,7 @@ package com.microsoft.ml.spark
 import com.microsoft.ml.spark.schema.ImageSchema
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.opencv.core.{Core, MatOfByte}
+import org.opencv.core.{Core, CvException, MatOfByte}
 import org.opencv.imgcodecs.Imgcodecs
 
 object ImageReader {
@@ -23,19 +23,22 @@ object ImageReader {
     */
   private[spark] def decode(filename: String, bytes: Array[Byte]): Option[Row] = {
     val mat = new MatOfByte(bytes: _*)
-    val decoded = Imgcodecs.imdecode(mat, Imgcodecs.CV_LOAD_IMAGE_COLOR)
-
-    if (decoded.empty()) {
-      None
-    } else {
-      val ocvBytes = new Array[Byte](decoded.total.toInt * decoded.elemSize.toInt)
-
-      // extract OpenCV bytes
-      decoded.get(0, 0, ocvBytes)
-
-      // type: CvType.CV_8U
-      Some(Row(filename, decoded.height, decoded.width, decoded.`type`, ocvBytes))
+    val decodedOpt = try {
+      Some(Imgcodecs.imdecode(mat, Imgcodecs.CV_LOAD_IMAGE_COLOR))
+    } catch {
+      case _:CvException => None
     }
+
+    decodedOpt match {
+      case Some(decoded) if !decoded.empty() =>
+        val ocvBytes = new Array[Byte](decoded.total.toInt * decoded.elemSize.toInt)
+        // extract OpenCV bytes
+        decoded.get(0, 0, ocvBytes)
+        // type: CvType.CV_8U
+        Some(Row(filename, decoded.height, decoded.width, decoded.`type`, ocvBytes))
+      case _ => None
+    }
+
   }
 
   /** Read the directory of images from the local or remote source

--- a/src/readers/src/test/scala/BinaryFileReaderSuite.scala
+++ b/src/readers/src/test/scala/BinaryFileReaderSuite.scala
@@ -3,10 +3,9 @@
 
 package com.microsoft.ml.spark
 
-import org.apache.spark.sql._
-import com.microsoft.ml.spark.schema.BinaryFileSchema.isBinaryFile
+import com.microsoft.ml.spark.FileReaderSuiteUtils._
 import com.microsoft.ml.spark.Readers.implicits._
-import FileReaderSuiteUtils._
+import com.microsoft.ml.spark.schema.BinaryFileSchema.isBinaryFile
 
 class BinaryFileReaderSuite extends TestBase {
 
@@ -32,7 +31,7 @@ class BinaryFileReaderSuite extends TestBase {
 
   test("with zip file") {
     /* remove when datasets/Images is updated */
-    creatZips
+    createZips
 
     val images = session.readBinaryFiles(imagesDirectory, recursive = true)
     assert(images.count == 74)

--- a/src/readers/src/test/scala/ImageReaderSuite.scala
+++ b/src/readers/src/test/scala/ImageReaderSuite.scala
@@ -3,12 +3,9 @@
 
 package com.microsoft.ml.spark
 
-import org.apache.spark.sql._
-import com.microsoft.ml.spark.schema.ImageSchema.isImage
-import com.microsoft.ml.spark.schema.BinaryFileSchema.isBinaryFile
-import org.apache.spark.input.PortableDataStream
-import com.microsoft.ml.spark.Readers.implicits._
 import com.microsoft.ml.spark.FileUtilities._
+import com.microsoft.ml.spark.Readers.implicits._
+import com.microsoft.ml.spark.schema.ImageSchema.isImage
 
 object FileReaderSuiteUtils {
   val fileLocation = s"${sys.env("DATASETS_HOME")}"
@@ -22,13 +19,13 @@ object FileReaderSuiteUtils {
       if (!zipfile.exists()) zipFolder(dir, zipfile)
   }
 
-  def creatZips(): Unit ={
+  def createZips(): Unit ={
     createZip(groceriesDirectory)
     createZip(cifarDirectory)
   }
 }
 
-import FileReaderSuiteUtils._
+import com.microsoft.ml.spark.FileReaderSuiteUtils._
 
 class ImageReaderSuite extends TestBase {
 
@@ -50,7 +47,7 @@ class ImageReaderSuite extends TestBase {
 
   test("with zip file") {
     /* remove when datasets/Images is updated */
-    creatZips
+    createZips
 
     val images = session.readImages(imagesDirectory, recursive = true)
     assert(isImage(images, "image"))


### PR DESCRIPTION
- It now sets the field to None when it encounters corrupt images