### PR TITLE
Changed save code to not modify the current working directory by removing the code that disposed the current file system

### DIFF
--- a/src/core/serialize/src/main/scala/Serializer.scala
+++ b/src/core/serialize/src/main/scala/Serializer.scala
@@ -83,10 +83,8 @@ object Serializer {
   def writeToHDFS[O](sc: SparkContext, obj: O, outputPath: Path, overwrite: Boolean)
                     (implicit ttag: TypeTag[O]): Unit = {
     val hadoopConf = sc.hadoopConfiguration
-    using(outputPath.getFileSystem(hadoopConf)) { fs =>
-      using(fs.create(outputPath, overwrite)) { os =>
-        write[O](obj, os)(ttag)
-      }.get
+    using(outputPath.getFileSystem(hadoopConf).create(outputPath, overwrite)) { os =>
+      write[O](obj, os)(ttag)
     }.get
   }
 
@@ -97,10 +95,8 @@ object Serializer {
     */
   def readFromHDFS[O](sc: SparkContext, path: Path)(implicit ttag: TypeTag[O]): O = {
     val hadoopConf = sc.hadoopConfiguration
-    using(path.getFileSystem(hadoopConf)) { fs =>
-      using(fs.open(path)) { in =>
-        read[O](in)(ttag)
-      }.get
+    using(path.getFileSystem(hadoopConf).open(path)) { in =>
+      read[O](in)(ttag)
     }.get
   }
 


### PR DESCRIPTION
This PR fixes the issue here:
https://github.com/Azure/mmlspark/issues/133
It looks like disposing the file system object was removing the currently set working directory and all other temporary settings, and a new file system object was getting created from the Hadoop configuration.