### PR TITLE
Script fixes and improvements

### DIFF
--- a/tools/config.sh
+++ b/tools/config.sh
@@ -55,7 +55,7 @@ _main_url() { echo "https://$MAIN_STORAGE.azureedge.net/$1"; }
 # The base URL for our installables
 defvar INSTALLER_URL "$(_main_url "installers")"
 # Directory for caching installers; if it is empty then no caching is used
-defvar INSTALLER_CACHE_DIR "$HOME/.mmlspark_cache"
+defvar -p INSTALLER_CACHE_DIR "$HOME/.mmlspark_cache"
 
 INSTALLATIONS=(
 
@@ -155,8 +155,8 @@ SBT.setup() {
 defvar SCALA_VERSION "2.11"
 defvar SCALA_FULL_VERSION "$SCALA_VERSION.8"
 SBT.init() {
-  setenv SCALA_VERSION "$SCALA_VERSION"
-  setenv SCALA_FULL_VERSION "$SCALA_FULL_VERSION"
+  defvar -E SCALA_VERSION "$SCALA_VERSION"
+  defvar -E SCALA_FULL_VERSION "$SCALA_FULL_VERSION"
 }
 
 Spark.setup() {
@@ -238,24 +238,24 @@ CNTK.init() {
 
 # Storage for build artifacts
 defvar STORAGE_CONTAINER "buildartifacts"
-defvar STORAGE_URL "$(_main_url "$STORAGE_CONTAINER")"
+defvar -X STORAGE_URL    "$(_main_url "$STORAGE_CONTAINER")"
 
 # Container for docs and maven/pip packages
-defvar DOCS_CONTAINER  "docs"
-defvar DOCS_URL        "$(_main_url "$DOCS_CONTAINER")"
-defvar MAVEN_CONTAINER  "maven"
-defvar -x MAVEN_URL     "$(_main_url "$MAVEN_CONTAINER")"
-defvar -d MAVEN_PACKAGE "com.microsoft.ml.spark:mmlspark_$SCALA_VERSION:<{MML_VERSION}>"
-defvar PIP_CONTAINER    "pip"
-defvar -x PIP_URL       "$(_main_url "$PIP_CONTAINER")"
-defvar -d PIP_PACKAGE   "mmlspark-<{MML_VERSION}>-py2.py3-none-any.whl"
+defvar DOCS_CONTAINER    "docs"
+defvar DOCS_URL          "$(_main_url "$DOCS_CONTAINER")"
+defvar MAVEN_CONTAINER   "maven"
+defvar -xX MAVEN_URL     "$(_main_url "$MAVEN_CONTAINER")"
+defvar -dX MAVEN_PACKAGE "com.microsoft.ml.spark:mmlspark_$SCALA_VERSION:<{MML_VERSION}>"
+defvar PIP_CONTAINER     "pip"
+defvar -xX PIP_URL       "$(_main_url "$PIP_CONTAINER")"
+defvar -dX PIP_PACKAGE   "mmlspark-<{MML_VERSION}>-py2.py3-none-any.whl"
 
 # E2E test cluster information
 defvar E2E_CLUSTER_NAME   "mmlsparktest"
 defvar E2E_RESOURCE_GROUP "mmlsparktest"
 defvar E2E_CLUSTER_SSH    "spark@${E2E_CLUSTER_NAME}-ssh.azurehdinsight.net"
 defvar E2E_PARALLEL_RUNS  "2"
-defvar CLUSTER_SDK_DIR    "/mml-sdk" # this is for all clusters
+defvar -X CLUSTER_SDK_DIR "/mml-sdk" # this is for all clusters
 
 # Demo cluster information
 defvar DEMO_CLUSTER_NAME   "mmlsparkdemo"

--- a/tools/hdi/setup-test-authkey.sh
+++ b/tools/hdi/setup-test-authkey.sh
@@ -2,8 +2,9 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in project root for information.
 
-SDK_DIR="<=<=fill-in-sdk-dir=>=>"
-NB_DIR="$SDK_DIR/notebooks" # This gets created as root, need to chown to spark
+# <=<= this line is replaced with variables defined with `defvar -X` =>=>
+
+NB_DIR="$CLUSTER_SDK_DIR/notebooks" # gets created as root, need to chown to spark
 
 # This is the public key used by the build to access the test cluster
 PUB_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0FUryXQloryZQGXVP9vOqBVsuUWihHs"

--- a/tools/misc/container-gc
+++ b/tools/misc/container-gc
@@ -26,7 +26,7 @@ GH_API="https://api.github.com/repos/Azure/mmlspark"
 github_prs="$(curl --silent --show-error "$GH_API/pulls" \
               | jq -r 'map(.number | tostring) | " " + join(" ") + " "')"
 
-vsort() { sort -t "+" -k 1,1 -V "$@"; }
+vsort() { sort -t "+" -k 1,2 -V "$@"; }
 
 now=0; _minute=$((60)); _hour=$((60*60)); _day=$((_hour*24))
 show-time() (

--- a/tools/runme/build.sh
+++ b/tools/runme/build.sh
@@ -251,13 +251,12 @@ _upload_artifacts_to_storage() {
   ( cd "$BUILD_ARTIFACTS"
     _ zip -qr9 "$tmp/$(basename "$BUILD_ARTIFACTS.zip")" * )
   local f txt
+  local varlinerx="^(.*)# +<=<= .*? =>=>(.*)\$"
   for f in "$TOOLSDIR/hdi/"*; do
     txt="$(< "$f")"
-    txt="${txt//<=<=fill-in-maven-package=>=>/com.microsoft.ml.spark:mmlspark_$SCALA_VERSION:$MML_VERSION}"
-    txt="${txt//<=<=fill-in-maven-url=>=>/$MAVEN_URL}"
-    txt="${txt//<=<=fill-in-pip-package=>=>/$PIP_URL/$PIP_PACKAGE}"
-    txt="${txt//<=<=fill-in-sdk-dir=>=>/$CLUSTER_SDK_DIR}"
-    txt="${txt//<=<=fill-in-url=>=>/$STORAGE_URL/$MML_VERSION}"
+    if [[ "$txt" =~ $varlinerx ]]; then
+      txt="${BASH_REMATCH[1]}$(_show_gen_vars)${BASH_REMATCH[2]}"
+    fi
     echo "$txt" > "$tmp/$(basename "$f")"
   done
   _ azblob upload-batch --source "$tmp" --destination "$STORAGE_CONTAINER/$MML_VERSION"

--- a/tools/runme/install.sh
+++ b/tools/runme/install.sh
@@ -46,7 +46,7 @@ _do_envinits() {
     if [[ "$cmd" = "export "*"="* ]]; then
       var="${cmd#export }"; var="${var%%=*}"; val="$(qstr "${!var}")"
     fi
-    # print only commands and setenvs that change values
+    # print only commands and var settings that change values
     if [[ "$var" = "" || "$cmd" != "export $var=$val" ]]; then show command "$cmd"; fi
   done
   eval "$script"
@@ -143,8 +143,8 @@ _install() { # libname
      || (                             " $where " != *" devel "*   ) ]]; then return
   fi
   local dir="$HOME/lib/$lib"
-  setenv "${envvar}_VERSION" "$ver"
-  setenv "${envvar}_HOME"    "$dir"
+  defvar -E "${envvar}_VERSION" "$ver"
+  defvar -xe "${envvar}_HOME"    "$dir"
   if [[ "x$prereq" != "x" ]] && ! eval "${prereq%|*}" > /dev/null 2>&1; then
     failwith "$libname: prerequisite failure: ${prereq##*|}"
   fi
@@ -157,8 +157,8 @@ _install() { # libname
   else Op="Installing"; _note_work "Install"; fi
   # avoid output up to here, so there's nothing unless we actually do something
   show section "$Op $libname v$ver in $dir"
-  show command setenv "${envvar}_VERSION" "$ver"
-  show command setenv "${envvar}_HOME"    "$dir"
+  show command export "${envvar}_VERSION=$ver"
+  show command export "${envvar}_HOME=$dir"
   if [[ "$update" = "Y" && "$(_verify_version "$libname")" = "" ]]; then
     show warning "Looks like $libname was already updated, noting new version"
     _ cd "$dir"


### PR DESCRIPTION
* When `CNTK_WHEELS` isn't specified for an environment, ignore it
  instead of failing.

* `defvar` has a new `-X` flag for variables that are all injected into
  generated scripts (currently only the HDI scripts).

* Use this to generate the HDI scripts instead of listing each value
  that is to be replaced.  (It also makes it easier to maintain since
  they use the same variable names as the rest of the runme scripts.)

* Fix the version sorting in container-gc, so no versions are
  dropped (using 1,2 includes the second key (after the `#`) so it gets
  considered for uniqueness too).