### PR TITLE
Add file name to notebook JSON decoding errors

### DIFF
--- a/tools/notebook/postprocess.py
+++ b/tools/notebook/postprocess.py
@@ -90,7 +90,15 @@ def postprocess_notebooks(input_dir, output_base_dir):
     import os
     import glob
     from nbformat import read, write, NO_CONVERT
-    notebooks = [(os.path.split(nbfile)[-1], read(nbfile, NO_CONVERT))
+
+    def _read(nbfile, to_conv):
+        try:
+            return read(nbfile, to_conv)
+        except Exception as e:
+            e.args += ("File name: {}".format(os.path.split(nbfile)[-1]),)
+            raise e
+
+    notebooks = [(os.path.split(nbfile)[-1], _read(nbfile, NO_CONVERT))
                  for nbfile in glob.glob(os.path.join(input_dir, "*.ipynb"))]
     notebooks_by_target = _postprocessed_notebooks_by_target(notebooks)
 


### PR DESCRIPTION
When there is any error message in the loading of notebooks from notebooks/samples/ the error message was related to the contents of the file instead of the file name.

The change improves the error message when failing to Decode notebook JSON by adding the file name to the error message.