### PR TITLE
Minor build fix

### DIFF
--- a/tools/misc/expunge
+++ b/tools/misc/expunge
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+. "$(dirname "${BASH_SOURCE[0]}")/../../runme"
+
+rm -f "/tmp/expunge-paths"
+
+numlines() { local n="$(wc -l "$@")"; echo "${n%% *}"; }
+
+run_filter() {
+  local label="$1";   shift
+  local azquery="$1"; shift
+  local jqquery="$1"; shift
+  #
+  local azcmd=(az storage blob list -c "deleted")
+  if [[ -n "$azquery" ]]; then azcmd+=("--query" "$azquery"); fi
+  #
+  local jqcmd=(jq -r '.[]')
+  if [[ -n "$jqquery" ]]; then jqcmd[2]+=" | select($jqquery)"; fi
+  #
+  local cmdstr=""
+  for x in "${azcmd[@]}"; do cmdstr+="$(maybe_qstr "$x") "; done
+  cmdstr+=$'\\\n  |'
+  for x in "${jqcmd[@]}"; do cmdstr+=" $(maybe_qstr "$x")"; done
+  show - "$label:"
+  show command "${cmdstr# }"
+  "${azcmd[@]}" | "${jqcmd[@]}" > "/tmp/expunge-chunk"
+  printf "%s paths\n" "$(numlines "/tmp/expunge-chunk")"
+  cat "/tmp/expunge-chunk" >> "/tmp/expunge-paths"
+  rm -f "/tmp/expunge-chunk"
+  echo ""
+}
+
+# Uses the lastModified field, which is the date that the "deleted" copy
+# was made, so the filtered dates apply to the time they were deleted.
+run_filter \
+  "blobs older than 2 months" \
+  "[?properties.lastModified<'$(date --iso --date="2 months ago")'].name" \
+  ""
+run_filter \
+  ".dev*+* blobs (from pr builds) older than 1 month" \
+  "[?properties.lastModified<'$(date --iso --date="1 month ago")'].name" \
+  "test(\"0([.][0-9]+)+.dev[0-9]+[+][0-9]\")"
+
+sort < "/tmp/expunge-paths" > "/tmp/expunge-paths-sorted"
+mv "/tmp/expunge-paths-sorted" "/tmp/expunge-paths"
+
+n="$(numlines "/tmp/expunge-paths")"
+printf "Total paths: %s\n\n" "$n"
+
+while read -r l; do
+  printf "\r%s %s...\e[K" $((n--)) "$l"
+  if ! az storage blob delete -c "deleted" -n "$l" > /dev/null
+  then printf "\rfail: %s\e[K\n" "$l"; fi
+done < "/tmp/expunge-paths"
+
+printf "\rDone.\e[K\n"
+
+rm -f "/tmp/expunge-paths"

--- a/tools/runme/build.sh
+++ b/tools/runme/build.sh
@@ -85,7 +85,7 @@ _sbt_build() {
   show section "Running SBT Build"
   local owd="$PWD" restore_opt="$(shopt -p nullglob)"; shopt -s nullglob
   cd "$SRCDIR"
-  local rmjars=( **/"target/scala-"*/!(*"-$MML_VERSION")".jar" )
+  local rmjars=( **/"target/scala-"*/!(*"-$MML_VERSION"@(|-*))".jar" )
   $restore_opt
   if [[ "${#rmjars[@]}" != "0" ]]; then
     show command "rm **/target/...stale-jars"

--- a/tools/runme/utils.sh
+++ b/tools/runme/utils.sh
@@ -248,11 +248,14 @@ get_suffix() {
 
 # ---< call_ifdef [_] fun arg... >----------------------------------------------
 # If the named function exists, calls it with the given arguments.  Calls only
-# functions, not external executables or builtins.
+# functions, not external executables or builtins.  Restores original working
+# directory if it was changed.
 call_ifdef() {
   local pfx=""; if [[ "$1" = "_" ]]; then pfx="_"; shift; fi
   local fun="$1"; shift
+  local owd="$PWD"
   if [[ "$(type -t "$fun")" = "function" ]]; then $pfx "$fun" "$@"; fi
+  cd "$owd"
 }
 
 # ---< deftag tag [supertag] >--------------------------------------------------


### PR DESCRIPTION
* `call_ifdef` needs to restore the working directory, without that
  `Spark.setup` would mess up the directory for `Spark.init` making it
  unable to find the Python zip files.

* When removing jars of other versions, make sure to not delete jars
  like `mmlspark_2.11-$ver-{javadoc,sources}.jar`.