### PR TITLE
Tweak README and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-![MMLSpark](https://mmlspark.azureedge.net/icons/mmlspark-96.png)
+![MMLSpark](https://mmlspark.azureedge.net/icons/mmlspark.svg)
 Microsoft Machine Learning for Apache Spark
 ===========================================
 
-<img title="Build Status" src="https://mmlspark.azureedge.net/icons/BuildStatus.png" align="right" />
+<img title="Build Status" align="right"
+     src="https://mmlspark.azureedge.net/icons/BuildStatus.svg" />
 
 MMLSpark provides a number of deep learning and data science tools for [Apache
 Spark](https://github.com/apache/spark), including seamless integration of Spark
@@ -18,6 +19,9 @@ Python 3.5+.  See the API documentation
 
 
 ## Salient features
+
+[<img src="https://mmlspark.azureedge.net/icons/ReleaseNotes.svg" align="right"
+  />](https://github.com/Azure/mmlspark/releases)
 
 * Easily ingest images from HDFS into Spark `DataFrame` ([example:301])
 * Pre-process image data using transforms from OpenCV ([example:302])
@@ -88,11 +92,11 @@ notebooks.  See the [documentation](docs/docker.md) for more on Docker use.
 MMLSpark can be conveniently installed on existing Spark clusters via the
 `--packages` option, examples:
 
-    spark-shell --packages Azure:mmlspark:0.8
+    spark-shell --packages Azure:mmlspark:0.9
 
-    pyspark --packages Azure:mmlspark:0.8
+    pyspark --packages Azure:mmlspark:0.9
 
-    spark-submit Azure:mmlspark:0.8 MyApp.jar
+    spark-submit Azure:mmlspark:0.9 MyApp.jar
 
 <img title="Script action submission" src="http://i.imgur.com/oQcS0R2.png" align="right" />
 
@@ -105,7 +109,7 @@ script actions, see [this
 guide](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-customize-cluster-linux#use-a-script-action-during-cluster-creation).
 
 The script action url is:
-<https://mmlspark.azureedge.net/buildartifacts/0.8/install-mmlspark.sh>.
+<https://mmlspark.azureedge.net/buildartifacts/0.9/install-mmlspark.sh>.
 
 If you're using the Azure Portal to run the script action, go to `Script
 actions` → `Submit new` in the `Overview` section of your cluster blade.  In the
@@ -121,7 +125,7 @@ To install MMLSpark on the
 [library from Maven coordinates](https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages)
 in your workspace.
 
-For the coordinates use: `com.microsoft.ml.spark:mmlspark:0.8`.  Then, under
+For the coordinates use: `com.microsoft.ml.spark:mmlspark:0.9`.  Then, under
 Advanced Options, use `https://mmlspark.azureedge.net/maven` for the repository.
 Ensure this library is attached to all clusters you create.
 
@@ -136,7 +140,7 @@ your `build.sbt`:
 
     ```scala
     resolvers += "MMLSpark Repo" at "https://mmlspark.azureedge.net/maven"
-    libraryDependencies += "com.microsoft.ml.spark" %% "mmlspark" % "0.8"
+    libraryDependencies += "com.microsoft.ml.spark" %% "mmlspark" % "0.9"
     ```
 
 ### Building from source

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -25,7 +25,7 @@ You can now select one of the sample notebooks and run it, or create your own.
 In the above, `microsoft/mmlspark` specifies the project and image name that you
 want to run.  There is another component implicit here which is the *tag* (=
 version) that you want to use — specifying it explicitly looks like
-`microsoft/mmlspark:0.8` for using the `0.8` tag.
+`microsoft/mmlspark:0.9` for using the `0.9` tag.
 
 Leaving `microsoft/mmlspark` by itself has an implicit `latest` tag, so it is
 equivalent to `microsoft/mmlspark:latest`.  The `latest` tag is identical to the
@@ -42,7 +42,7 @@ that you will probably want to use can look as follows:
                -e ACCEPT_EULA=y \
                -p 127.0.0.1:80:8888 \
                -v ~/myfiles:/notebooks/myfiles \
-               microsoft/mmlspark:0.8
+               microsoft/mmlspark:0.9
 
 In this example, backslashes are used to break things up for readability; you
 can enter it as one long like.  Note that in powershell, the `myfiles` local
@@ -52,7 +52,7 @@ path and line breaks looks a little different:
                -e ACCEPT_EULA=y `
                -p 127.0.0.1:80:8888 `
                -v C:\myfiles:/notebooks/myfiles `
-               microsoft/mmlspark:0.8
+               microsoft/mmlspark:0.9
 
 Let's break this command and go over the meaning of each part:
 
@@ -133,7 +133,7 @@ Let's break this command and go over the meaning of each part:
       ...
       model.write().overwrite().save('myfiles/myTrainedModel.mml')
 
-* **`microsoft/mmlspark:0.8`**
+* **`microsoft/mmlspark:0.9`**
 
   Finally, this specifies an explicit version tag for the image that we want to
   run.

--- a/tools/build-pr/report
+++ b/tools/build-pr/report
@@ -16,10 +16,10 @@ fi
 ICONS_URL="https://$MAIN_STORAGE.blob.core.windows.net/icons"
 icon="$ICONS_URL/Robot"
 case "${AGENT_JOBSTATUS,,}" in
-  ( succeeded ) icon+="2.png"; box="![PASS]($icon) Pass";       state="success" ;;
-  ( canceled  ) icon+="1.png"; box="![CANCEL]($icon) Canceled"; state="error"   ;;
-  ( failed    ) icon+="0.png"; box="![FAIL]($icon) Fail";       state="failure" ;;
-  ( *         ) icon+="1.png"; box="![$AGENT_JOBSTATUS]($icon) Unknown"; state="error" ;;
+  ( succeeded ) icon+="2.svg"; box="![PASS]($icon) Pass";       state="success" ;;
+  ( canceled  ) icon+="1.svg"; box="![CANCEL]($icon) Canceled"; state="error"   ;;
+  ( failed    ) icon+="0.svg"; box="![FAIL]($icon) Fail";       state="failure" ;;
+  ( *         ) icon+="1.svg"; box="![$AGENT_JOBSTATUS]($icon) Unknown"; state="error" ;;
 esac
 
 if [[ "$BUILDPR" = "" ]]; then

--- a/tools/misc/mmlspark.svg
+++ b/tools/misc/mmlspark.svg
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1"
-     width="262" height="200" viewbox="0 0 242 180">
-  <g transform="translate(10,10)">
-    <path style="fill:#00bbf1;fill-opacity:1;stroke:none"
-          d="M 130,180 v -180 l -38,142 Z" />
-    <path style="fill:#7fdcf7;fill-opacity:1;stroke:none"
-          d="M 130,180 v -180 l 38,142 Z" />
-    <path style="fill:#00bbf1;fill-opacity:1;stroke:none"
-          d="M 0,180 h 112 l -32,-32 Z" />
-    <path style="fill:#7fdcf7;fill-opacity:1;stroke:none"
-          d="M 148,180 h 76 l -44,-32 Z" />
-    <path style="fill:#7fdcf7;fill-opacity:1;stroke:none"
-          d="M 177,139 l -7,-26 l 72,-29 l -47,68 Z" />
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="170.07292" height="129.0625"
+     viewBox="0 0 179.99384 136.59115"
+     version="1.1">
+  <g transform="translate(-9.788797,-142.52586)">
+    <g transform="matrix(0.26458333,0,0,0.26458333,65.483588,175.64287)">
+      <path style="fill:#00bbf1;fill-opacity:1;stroke:none"
+            d="M -190.5,371.08333 H 105.83333 L 21.166667,286.41667 Z" />
+      <path style="fill:#00bbf1;fill-opacity:1;stroke:none"
+            d="M 153.45833,371.08333 52.916667,270.54167 153.45833,-105.16667 Z" />
+      <path style="fill:#7fdcf7;fill-opacity:1;stroke:none"
+            d="m 153.45833,371.08333 v -476.25 L 254,270.54167 Z" />
+      <path style="fill:#7fdcf7;fill-opacity:1;stroke:none"
+            d="M 201.08333,371.08333 H 402.16667 L 285.75,286.41667 Z" />
+      <path style="fill:#7fdcf7;fill-opacity:1;stroke:none"
+            d="m 277.8125,262.60417 -18.52083,-68.79167 190.5,-76.72917 L 325.4375,297 Z" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
* Switch to using `mmlspark.svg`, so it looks better.  Including a new
  SVG that can scale.

* Switch the build status icons to SVGs, with a standard text-label
  below the robot face.

* Add a release notes link, use an SVG button-like image so it can float
  right.

* Also bump the hard-wired version for the upcoming v0.9 release.