### PR TITLE
Fixing reader to display full path to image

### DIFF
--- a/src/readers/src/main/scala/BinaryFileFormat.scala
+++ b/src/readers/src/main/scala/BinaryFileFormat.scala
@@ -160,12 +160,14 @@ class BinaryFileFormat extends TextBasedFileFormat with DataSourceRegister {
     (file: PartitionedFile) => {
       val fileReader = new HadoopFileReader(file, broadcastedHadoopConf.value.value, subsample, inspectZip, seed)
       Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => fileReader.close()))
-      fileReader.map { bytes =>
+      fileReader.map { record =>
+        val recordPath = record._1
+        val bytes = record._2
         val row = new GenericInternalRow(2)
-        row.update(0, UTF8String.fromString(file.filePath))
+        row.update(0, UTF8String.fromString(recordPath))
         row.update(1, bytes.getBytes)
         val outerRow = new GenericInternalRow(1)
-        outerRow.update(0,row)
+        outerRow.update(0, row)
         outerRow
       }
     }
@@ -184,7 +186,7 @@ private[spark] class HadoopFileReader(file: PartitionedFile,
                                       subsample: Double,
                                       inspectZip: Boolean,
                                       seed: Long)
-  extends Iterator[BytesWritable] with Closeable {
+  extends Iterator[(String, BytesWritable)] with Closeable {
 
   private val iterator = {
     val fileSplit = new FileSplit(
@@ -196,12 +198,12 @@ private[spark] class HadoopFileReader(file: PartitionedFile,
     val hadoopAttemptContext = new TaskAttemptContextImpl(conf, attemptId)
     val reader = new BinaryRecordReader(subsample, inspectZip, seed)
     reader.initialize(fileSplit, hadoopAttemptContext)
-    new RecordReaderIterator(reader)
+    new KeyValueReaderIterator(reader)
   }
 
   override def hasNext: Boolean = iterator.hasNext
 
-  override def next(): BytesWritable = iterator.next()
+  override def next(): (String, BytesWritable) = iterator.next()
 
   override def close(): Unit = iterator.close()
 

--- a/src/readers/src/main/scala/KeyValueReaderIterator.scala
+++ b/src/readers/src/main/scala/KeyValueReaderIterator.scala
@@ -1,0 +1,54 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package org.apache.spark.binary
+
+import java.io.Closeable
+import org.apache.hadoop.mapreduce.RecordReader
+
+// Based on:
+// https://github.com/apache/spark/blob/master/sql/core/src/main/scala/
+//   org/apache/spark/sql/execution/datasources/RecordReaderIterator.scala
+
+/** An adaptor from a Hadoop [[RecordReader]] to an [[Iterator]] over the keys and values returned.
+  *
+  * This file is based on spark's RecordReaderIterator.
+  */
+private class KeyValueReaderIterator[K, V] (
+  private[this] var rowReader: RecordReader[K, V]) extends Iterator[(K, V)] with Closeable {
+  private[this] var havePair = false
+  private[this] var finished = false
+
+  override def hasNext: Boolean = {
+    if (!finished && !havePair) {
+      finished = !rowReader.nextKeyValue
+      if (finished) {
+        // Close and release the reader here; close() will also be called when the task
+        // completes, but for tasks that read from many files, it helps to release the
+        // resources early.
+        close()
+      }
+      havePair = !finished
+    }
+    !finished
+  }
+
+  override def next(): (K, V) = {
+    if (!hasNext) {
+      throw new java.util.NoSuchElementException("End of stream")
+    }
+    havePair = false
+    (rowReader.getCurrentKey, rowReader.getCurrentValue)
+  }
+
+  override def close(): Unit = {
+    if (rowReader != null) {
+      try {
+        rowReader.close()
+      } finally {
+        rowReader = null
+      }
+    }
+  }
+
+}

--- a/src/readers/src/test/scala/ImageReaderSuite.scala
+++ b/src/readers/src/test/scala/ImageReaderSuite.scala
@@ -54,6 +54,10 @@ class ImageReaderSuite extends TestBase with FileReaderUtils {
 
     val images = session.readImages(imagesDirectory, recursive = true)
     assert(ImageSchema.isImage(images, "image"))
+    // Validate path contains an image
+    val extensions = Seq(".jpg", ".png")
+    val sampleImagePath = images.select("image.path").take(1)(0)(0).toString()
+    assert(extensions.exists(ext => sampleImagePath.endsWith(ext)))
     assert(images.count == 72)
 
     val images1 = session.readImages(imagesDirectory, recursive = true, inspectZip = false)


### PR DESCRIPTION
Fixing image reader so that path in schema would contain the full path to image (or file) instead of just the zip file and added a test to validate