### PR TITLE
Documentation formatting corrections

### DIFF
--- a/notebooks/samples/202 - Amazon Book Reviews - Word2Vec.ipynb
+++ b/notebooks/samples/202 - Amazon Book Reviews - Word2Vec.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 202 - Training and Evaluaiting CNTK Models in Spark ML Pipelines\n",
+    "## 202 - Training and Evaluating CNTK Models in Spark ML Pipelines\n",
     "\n",
     "Yet again, now using the `Word2Vec` Estimator from Spark.  We can use the tree-based\n",
     "learners from spark in this scenario due to the lower dimensionality representation of\n",

--- a/src/clean-missing-data/src/main/scala/CleanMissingData.txt
+++ b/src/clean-missing-data/src/main/scala/CleanMissingData.txt
@@ -1,17 +1,20 @@
 Removes missing values from input dataset.
 
 The following modes are supported:
+
 - Mean   - replaces missings with the mean of fit column
 - Median - replaces missings with approximate median of fit column
 - Custom - replaces missings with custom value specified by user
 
 For mean and median modes, only numeric column types are supported,
 specifically:
+
 - int
 - long
 - float
 - double
 
 For custom mode, the types above are supported and additionally:
+
 - str
 - bool

--- a/src/codegen/src/main/scala/PySparkWrapper.scala
+++ b/src/codegen/src/main/scala/PySparkWrapper.scala
@@ -74,6 +74,7 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
         |        Set the (keyword only) parameters
         |
         |        Args:
+        |
         |$paramDocString
         |        "\""
         |        if hasattr(self, \"_input_kwargs\"):
@@ -94,6 +95,7 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
         |        "\""
         |
         |        Args:
+        |
         |$explanation
         |
         |        "\""
@@ -109,6 +111,7 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
         |        "\""
         |
         |        Returns:
+        |
         |            $docType: ${res(1)}
         |        "\""
         |        return self.getOrDefault(self.$pname)
@@ -122,6 +125,7 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
         |        "\""
         |
         |        Returns:
+        |
         |            $docType: ${res(1)}
         |        "\""
         |        return self._cache.get(\"$pname\", None)
@@ -297,7 +301,7 @@ abstract class PySparkWrapper(entryPoint: PipelineStage,
     //val classParamDocString = classParamDocList.mkString("\n")
     val classParamDocString = {
       if (classParamDocList.isEmpty) ""
-      else scopeDepth + "Args:\n" + classParamDocList.mkString("\n")
+      else scopeDepth + "Args:\n\n" + classParamDocList.mkString("\n")
     }
 
     classTemplate(importsString, inheritanceString,

--- a/src/compute-model-statistics/src/main/scala/ComputeModelStatistics.txt
+++ b/src/compute-model-statistics/src/main/scala/ComputeModelStatistics.txt
@@ -4,6 +4,7 @@ models specified
 The possible metrics are:
 
 Binary Classifiers:
+
 - "AreaUnderROC"
 - "AUC"
 - "accuracy"
@@ -11,6 +12,7 @@ Binary Classifiers:
 - "all"
 
 Regression Classifiers:
+
 - "mse"
 - "rmse"
 - "r2"

--- a/src/compute-per-instance-statistics/src/main/scala/ComputePerInstanceStatistics.txt
+++ b/src/compute-per-instance-statistics/src/main/scala/ComputePerInstanceStatistics.txt
@@ -1,8 +1,10 @@
 Evaluates the given scored dataset with per instance metrics.
 
 The Regression metrics are:
+
 - "L1_loss"
 - "L2_loss"
 
 The Classification metrics are:
+
 - "log_loss"

--- a/src/data-conversion/src/main/scala/DataConversion.txt
+++ b/src/data-conversion/src/main/scala/DataConversion.txt
@@ -1,5 +1,6 @@
 Converts the specified list of columns to the specified type.  The types
 are specified by the following strings:
+
 - "boolean"
 - "byte"
 - "short"

--- a/src/summarize-data/src/main/scala/SummarizeData.txt
+++ b/src/summarize-data/src/main/scala/SummarizeData.txt
@@ -1,6 +1,7 @@
 Compute summary statistics for the dataset.
 
 Statistics to be computed:
+
 - counts
 - basic
 - sample

--- a/src/train-classifier/src/main/scala/TrainClassifier.txt
+++ b/src/train-classifier/src/main/scala/TrainClassifier.txt
@@ -2,6 +2,7 @@ Trains a classifier model
 
 The currently supported models and the names to be provided in the
 "model" parameter are:
+
 - Logistic Regression - "LogisticRegression"
 - Decision Tree - "DecisionTreeClassification"
 - Random Forest - "RandomForestClassification"


### PR DESCRIPTION
Some docstrings did not format correctly on the Pyspark doc pages due
to missing blank lines. Added the blank lines back in to make the
documentation pages pretty again.

Corrected typo in title of notebook.