### PR TITLE
Some build and other script fixes

### DIFF
--- a/notebooks/samples/103 - Before and After MMLSpark.ipynb
+++ b/notebooks/samples/103 - Before and After MMLSpark.ipynb
@@ -15,7 +15,7 @@
     "/landing-page/1000638_books_landing-page_bookstore-photo-01.jpg\" /><br /></p>\n",
     "\n",
     "In this tutorial, we perform the same classification task in two\n",
-    "diffeerent ways: once using plain **`pyspark`** and once using the\n",
+    "different ways: once using plain **`pyspark`** and once using the\n",
     "**`mmlspark`** library.  The two methods yield the same performance,\n",
     "but one of the two libraries is drastically simpler to use and iterate\n",
     "on (can you guess which one?).\n",

--- a/tools/config.sh
+++ b/tools/config.sh
@@ -14,6 +14,8 @@ defvar -xp HOME; mkdir -p "$HOME"
 # * ver: The version of the library.  This version can be used in other settings
 #   by using "<{ver}>", it is also available in the `.setup` and `.init` hooks
 #   as "$ver".
+# Note: actually all keys can be used with "<{key}>" potentially with bash-like
+# variable substitutions (similar to `defvar -d`).
 # * lib: The name of the directory (in ~/lib) to install to, defaults to the
 #   library name in lowercase.
 # * envvar: An environment variable prefix to set to the library's version and
@@ -94,12 +96,11 @@ INSTALLATIONS=(
   vers:   "cat version|<{ver}>"
   where:  "devel build"
 
-  CNTK ver: "2.1"
-  url:    "$INSTALLER_URL/CNTK-2-1-Linux-64bit-CPU-Only.tar.gz"
+  CNTK ver: "2.1" dashver: "<{ver//./-}>"
+  url:    "$INSTALLER_URL/CNTK-<{dashver}>-Linux-64bit-CPU-Only.tar.gz"
   sha256: "6fef06b6c9b9bdb782c0d3c4b860c7f7834a04bdf02a6e79938551dfaceea3c1"
   exes:   "cntk"
-  # Note: no good way to find the installed version, see cntk pr #2228
-  vers:   "ls cntk/lib/libCntk.Core-*.so|*/libCntk.Core-<{ver}>.so"
+  vers:   "cat version.txt|CNTK-<{dashver}>"
   bindir: "cntk/bin"
   where:  "devel build"
 

--- a/tools/misc/container-gc
+++ b/tools/misc/container-gc
@@ -4,7 +4,7 @@
 
 . "$(dirname "${BASH_SOURCE[0]}")/../../runme"
 
-types=(S M P D)
+types=(S M P D R)
 declare -A S=([container]="$STORAGE_CONTAINER"
               [path]=""
               [suffix]="/")

--- a/tools/pydocs/build
+++ b/tools/pydocs/build
@@ -10,7 +10,7 @@ show section "Building Python Documentation"
 here="$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)"
 pydocsrc="$BUILD_ARTIFACTS/pydocsrc"
 
-cd "$BUILD_ARTIFACTS/docs"
+_mcd "$BUILD_ARTIFACTS/docs"
 _rm "pyspark"; _md "pyspark"
 
 show - "Copying source files"


### PR DESCRIPTION
* Hack around the problem of running sbt in bash: sbt uses a newer jline
  version and it doesn't restore some tty settings.  Use stty to
  properly restore them -- and add a check that will throw an error when
  we update to a newer version since this problem should be resolved in
  an upcoming version.

* Improve substitutions of `<{var}>` in delayed variables, and extend
  them with bash variable substitutions.

* Improve `<{ver}>` substitutions in INSTALLATION entries using the
  above, so now they work with any keys and include bash substitutions.

* For CNTK installation, use the "version.txt" file in the root to
  verify the installed version, instead of the previous hack.

* Make `container-gc` account for the R container.

* `pydocs/build`: use `_mcd` instead of `cd` to make the pyspark doc dir
  exist instead of relying on it pre-existing (which resulted in the
  docs building in the root instead).