### PR TITLE
A few more build/script fixes

### DIFF
--- a/tools/bin/mml-exec
+++ b/tools/bin/mml-exec
@@ -20,7 +20,7 @@ else echo "Could not find \"runme\"" 1>&2; exit 1; fi
 # If we let spark guess a driver, it can find "python2.7" in the path (eg, the
 # system's installation) and use that; so do this to force it to use "python" in
 # our path, which is a symlink to the conda python.
-if [[ "x$PYSPARK_PYTHON" = "x" ]]; then export PYSPARK_PYTHON="python"; fi
+if [[ -z "$PYSPARK_PYTHON" ]]; then export PYSPARK_PYTHON="python"; fi
 
 if [[ "$exe" == "jupyter-notebook" ]]; then
   if [[ "${#args[@]}" = 0 ]]; then args=""

--- a/tools/build-pr/checkout
+++ b/tools/build-pr/checkout
@@ -24,7 +24,7 @@ printf 'PR BUILD for #%s\n  repo: %s\n  ref: %s\n  sha1: %s\n' \
 
 git checkout "master" > /dev/null 2>&1
 oldbr="$(git for-each-ref --format="%(refname:short)" "refs/heads/pr-*")"
-if [[ "x$oldbr" != "x" ]]; then git branch -D $oldbr; fi
+if [[ -n "$oldbr" ]]; then git branch -D "$oldbr"; fi
 
 text="A build has started."
 post_status "pending" "$text"

--- a/tools/build-pr/shared.sh
+++ b/tools/build-pr/shared.sh
@@ -13,7 +13,7 @@ fi
 
 T=""
 _get_T() {
-  if [[ "x$T" = "x" ]]; then
+  if [[ -z "$T" ]]; then
     T="$(__ az keyvault secret show --vault-name mmlspark-keys --name github-auth \
          | jq -r ".value" | base64 -d)"
   fi

--- a/tools/config.sh
+++ b/tools/config.sh
@@ -149,9 +149,9 @@ defvar -p TEST_RESULTS    "$BASEDIR/TestResults"
 # Specific installation functions
 
 SBT.setup() {
-  local f="$SRCDIR/project/build.properties" txt="sbt.version = $SBT_VERSION"
+  local f="$SRCDIR/project/build.properties" txt="sbt.version=$SBT_VERSION"
   if [[ ! -e "$f" ]]; then echo "$txt" > "$f"; return; fi
-  if [[ "x$(< "$f")" != "x$txt" ]]; then failwith "$f exists"; fi
+  if [[ "$(< "$f")" != "$txt" ]]; then failwith "$f exists with unexpected contents"; fi
 }
 defvar SCALA_VERSION "2.11"
 defvar SCALA_FULL_VERSION "$SCALA_VERSION.8"

--- a/tools/docker/bin/eula
+++ b/tools/docker/bin/eula
@@ -9,5 +9,5 @@ echo ""
 echo "(Note: you can also use \"-e ACCEPT_EULA=Y\" to indicate agreement.)"
 echo ""
 read -ep "Do you agree to the EULA? " R
-if [[ "x${R,,}" != @("xy"|"xyes") ]]; then echo "Bye."
+if [[ "${R,,}" != @("y"|"yes") ]]; then echo "Bye."
 else ACCEPT_EULA=Y launcher; fi

--- a/tools/misc/container-gc
+++ b/tools/misc/container-gc
@@ -4,7 +4,7 @@
 
 . "$(dirname "${BASH_SOURCE[0]}")/../../runme"
 
-types=(S M P D R)
+types=(S M P R D)
 declare -A S=([container]="$STORAGE_CONTAINER"
               [path]=""
               [suffix]="/")
@@ -15,13 +15,13 @@ declare -A P=([container]="$PIP_CONTAINER"
               [path]=""
               [prefix]="mmlspark-"
               [suffix]="-py2.py3-none-any.whl")
-declare -A D=([container]="$DOCS_CONTAINER"
-              [path]=""
-              [suffix]="")
 declare -A R=([container]="$R_CONTAINER"
               [path]=""
               [prefix]="mmlspark-"
               [suffix]=".zip")
+declare -A D=([container]="$DOCS_CONTAINER"
+              [path]=""
+              [suffix]="")
 
 set -e
 shopt -s nullglob
@@ -116,47 +116,53 @@ cachedir="$HOME/.$(basename "$0")"; mkdir -p "$cachedir"
  done)
 
 get-ver-info() (
-  v="$1" info="{}"
+  v="$1" info="$tmp-info"
+  echo "{}" > "$info"
   if [[ -r "$cachedir/$v" ]]; then return; fi
   for t in "${types[@]}"; do
     declare -n X="$t"
     pfx="${X[path]}${X[path]:+/}${X[prefix]}$v${X[suffix]}"
-    info="$(az storage blob list -c "${X[container]}" --prefix "$pfx" \
-            | jq --argjson i "$info" --arg pfx "$pfx" '$i + {"'"$t"'":
-                map(select((.name == $pfx)
-                           or ((.name | startswith($pfx))
-                               and (($pfx | endswith("/"))
-                                    or (.name | .[($pfx | length):]
-                                        | startswith("/"))))))}')"
+    az storage blob list -c "${X[container]}" --prefix "$pfx" \
+    | jq --slurpfile i "$info" --arg pfx "$pfx" '$i[0] + {"'"$t"'":
+        map(select((.name == $pfx)
+                   or ((.name | startswith($pfx))
+                       and (($pfx | endswith("/"))
+                            or (.name | .[($pfx | length):]
+                                | startswith("/"))))))}' \
+    > "$info-new"; mv "$info-new" "$info"
   done
   #
   label="$(jq -r '.S | map(select(.name | endswith("/.label")) | .name) | .[]' \
-                 <<<"$info")"
+                 < "$info")"
   if [[ "$label" = *$'\n'* ]]; then failwith "found multiple .label blobs"; fi
   if [[ -n "$label" ]]; then
     az storage blob download -c "${S[container]}" -n "$label" -f "$tmp" > /dev/null
     label="$(< "$tmp")"
     rm -f "$tmp"
   fi
-  info="$(jq --arg l "$label" '. + {label: $l}' <<<"$info")"
+  jq --arg l "$label" '. + {label: $l}' \
+     < "$info" > "$info-new"; mv "$info-new" "$info"
   #
   az storage blob download -c "${S[container]}" -n "$v/Build.md" -f "$tmp.md" > /dev/null
   binfo="$(< "$tmp.md")"; rm -f "$tmp.md"
   if [[ -z "$binfo" ]]; then binfo="(No info: \"Build.md\" file not found)"; fi
-  info="$(jq --arg b "$binfo" '. + {buildinfo: $b}' <<<"$info")"
+  jq --arg b "$binfo" '. + {buildinfo: $b}' \
+     < "$info" > "$info-new"; mv "$info-new" "$info"
   #
   rx="\n#+ [^\n]* build [^\n]*github PR #([0-9]+)"
   rx=$'\n'"#+ [^"$'\n'"]* build [^"$'\n'"]*github PR #([0-9]+)"
   if [[ "$binfo" =~ $rx ]]; then pr="${BASH_REMATCH[1]}"; else pr=""; fi
-  info="$(jq --arg pr "$pr" '. + {github_pr: $pr}' <<<"$info")"
+  jq --arg pr "$pr" '. + {github_pr: $pr}' \
+     < "$info" > "$info-new"; mv "$info-new" "$info"
   #
-  info="$(jq --argjson now "$(date +"%s")" \
+  jq --argjson now "$(date +"%s")" \
              '. + (to_entries
                    | map(select((.value | type) == "array") | .value) | add
                    | map(.properties.lastModified | sub("\\+00:00$"; "Z") | fromdate)
-                   | sort | {created: $now, mintime: .[0], maxtime: .[-1]})' <<<"$info")"
+                   | sort | {created: $now, mintime: .[0], maxtime: .[-1]})' \
+     < "$info" > "$info-new"; mv "$info-new" "$info"
   #
-  echo "$info" > "$cachedir/$v"
+  mv "$info" "$cachedir/$v"
 )
 
 show-all-oneline() {

--- a/tools/runme/install.sh
+++ b/tools/runme/install.sh
@@ -106,7 +106,7 @@ _unpack_zip() {
 }
 
 _unpack_sh() {
-  if [[ "x$instcmd" != "x" ]]; then eval "_ $instcmd"
+  if [[ -n "$instcmd" ]]; then eval "_ $instcmd"
   else failwith "sh package without instcmd: $1"; fi
 }
 
@@ -123,7 +123,7 @@ _retrieve_file() { # url file sha256
   fi
   _curl --output "$target" "$url"
   local sha256sum="$(__ sha256sum "$target")"; sha256sum="${sha256sum%% *}"
-  if [[ "x$sha256sum" = "x" ]]; then failwith "could not get sha256 checksum"; fi
+  if [[ -z "$sha256sum" ]]; then failwith "could not get sha256 checksum"; fi
   if [[ "$sha256sum" != "$sha256" ]]; then
     failwith "sha256 checksum failed for $target (retrieved from $url)"
   fi
@@ -143,9 +143,9 @@ _install() { # libname
      || (                             " $where " != *" devel "*   ) ]]; then return
   fi
   local dir="$HOME/lib/$lib"
-  defvar -E "${envvar}_VERSION" "$ver"
+  defvar -E  "${envvar}_VERSION" "$ver"
   defvar -xe "${envvar}_HOME"    "$dir"
-  if [[ "x$prereq" != "x" ]] && ! eval "${prereq%|*}" > /dev/null 2>&1; then
+  if [[ -n "$prereq" ]] && ! eval "${prereq%|*}" > /dev/null 2>&1; then
     failwith "$libname: prerequisite failure: ${prereq##*|}"
   fi
   if [[ "$(_verify_version -q "$libname")" = "" ]]; then

--- a/tools/runme/utils.sh
+++ b/tools/runme/utils.sh
@@ -11,8 +11,9 @@
 # * `-x`: export the variable,
 # * `-X`: mark the variable to be included in generated script resources
 #         like the HDI script actions,
-# * `-e`: set in the user environment (in "$HOME/.mmlspark_profile"),
-# * `-E`: implies `-xXe`,
+# * `-e`: set in the user environment in "$HOME/.mmlspark_profile"
+#         (implies -f to avoid "sticky values"),
+# * `-E`: shorthand for `-xXef`,
 # * `-p`: resolve the value to an absolute path from where we are,
 # * `-f`: set the value even if it's already set,
 # * `-d`: define values with delayed references to other variables using
@@ -23,7 +24,7 @@ _gen_vars=()
 defvar() {
   local opts=""; while [[ "x$1" == "x-"* ]]; do opts+="${1:1}"; shift; done
   local var="$1" val v; shift
-  if [[ "$opts" == *"f"* || -z "${!var+x}" ]]; then
+  if [[ "$opts" == *[feE]* || -z "${!var+x}" ]]; then
     val=""; for v; do val+="$v"; done; printf -v "$var" "%s" "$val"; fi
   if [[ "$opts" == *"p"* && "x${!var}" != "/"* ]]; then
     printf -v "$var" "%s" "$(realpath -m "${!var}")"; fi
@@ -92,13 +93,10 @@ esac; shift; done
 # generic output.  $hide_in_log can be set to a string holding sensitive
 # information that should be hidden in the output.  The display uses "$HOME"
 # instead of the actual value whenever it appears.
-first_show="Y"
 hide_in_log=""
 show() {
   local tag="$1"; shift
-  if [[ "$first_show" = "Y" ]]; then first_show="N";
-  elif [[ "x$tag" = "xsection" ]]; then echo ""
-  fi
+  if [[ "x$tag" = "xsection" ]]; then echo ""; fi
   if [[ "x$tag" = "x-" ]]; then tag=""
   elif [[ "$BUILDMODE" = "server" ]]; then tag="##[$tag]"
   else case "$tag" in


### PR DESCRIPTION
* Fix a bug that was introduced in f1704d3: translations of the old
  `setenv` into `defvar -e` should have used the -f flag to force the
  values.  This bug would lead to the problem of "sticky" versions that
  don't change.  Make `-e` imply `-f`, which also makes sense since if
  we're changing a user's profile then we need to force a change of
  whatever is currently there.

* `container-gc`: use a file for collecting info, to avoid getting
  errors about going over the shell limits.

* Some more bash-isms.