### PR TITLE
More script fixes

### DIFF
--- a/tools/build-pr/checkout
+++ b/tools/build-pr/checkout
@@ -16,7 +16,10 @@ if [[ "$BUILDPR" = "" ]]; then exit 0; fi
 echo "##[section] PR Build for #$BUILDPR"
 
 get_pr_info
-api "pulls/$BUILDPR" - '.head.sha // error("no such PR")' > /dev/null
+if [[ "$(api "pulls/$BUILDPR" - '.state')" != "open" ]]; then
+  failwith "PR#$BUILDPR is not open"
+fi
+
 repourl="https://github.com/$REPO"
 
 printf 'PR BUILD for #%s\n  repo: %s\n  ref: %s\n  sha1: %s\n' \

--- a/tools/build-pr/shared.sh
+++ b/tools/build-pr/shared.sh
@@ -48,10 +48,11 @@ GURL="" SHA1="" REPO="" REF=""
 
 get_pr_info() {
   if [[ "$SHA1" != "" ]]; then return; fi
-  SHA1="$(api "pulls/$BUILDPR" - '.head.sha')"
-  REPO="$(api "pulls/$BUILDPR" - '.head.repo.full_name')"
-  REF="$( api "pulls/$BUILDPR" - '.head.ref')"
-  GURL="$(api "pulls/$BUILDPR" - '.html_url')"
+  SHA1="$(api "pulls/$BUILDPR" - '.head.sha // empty')"
+  REPO="$(api "pulls/$BUILDPR" - '.head.repo.full_name // empty')"
+  REF="$( api "pulls/$BUILDPR" - '.head.ref // empty')"
+  GURL="$(api "pulls/$BUILDPR" - '.html_url // empty')"
+  if [[ -z "$SHA1" ]]; then failwith "no such PR: $BUILDPR"; fi
 }
 
 # post a status, only if we're running all tests

--- a/tools/runme/utils.sh
+++ b/tools/runme/utils.sh
@@ -399,7 +399,7 @@ _parse_PUBLISH() { _parse_tags PUBLISH _publish_info; }
 
 # Defines $MML_VERSION and $MML_BUILD_INFO
 _set_build_info() {
-  local info version is_latest
+  local info version is_latest owd="$PWD"; cd "$BASEDIR"
   if [[ -n "$MML_BUILD_INFO" && -n "$MML_VERSION" && -n "$MML_LATEST" ]]; then
     # make it possible to avoid running git
     info="$MML_BUILD_INFO"; version="$MML_VERSION"; is_latest="$MML_LATEST"
@@ -417,7 +417,6 @@ _set_build_info() {
                  echo "//$line"; done)"
     if ! git diff-index --quiet HEAD; then info+=" (dirty)"; fi
   else
-    local owd="$PWD"; cd "$BASEDIR"
     # sanity checks for version tags
     local t rx="(0|[1-9][0-9]*)"; rx="^v$rx[.]$rx([.][1-9][0-9]*)?$"
     for t in $(git tag -l); do
@@ -462,8 +461,8 @@ _set_build_info() {
     if [[ "$version" = "${tag#v}" && "$tag" = "$latest" ]]
     then is_latest="yes"; else is_latest="no"; fi
     #
-    cd "$owd"
   fi
+  cd "$owd"
   defvar -xX MML_VERSION    "$version"
   defvar -xX MML_BUILD_INFO "$info"
   defvar -xX MML_LATEST     "$is_latest"


### PR DESCRIPTION
* Throw a good error message when given a bad PR number.

* Also throw an error message when given a closed PR number (could allow
  it, but the PR branch is likely deleted anyway).

* cd into `$BASEDIR` before using `git` to get the build info.