### PR TITLE
Updating per instance stats module to work for spark ML estimators in addition to TrainClassifier and TrainRegressor

### DIFF
--- a/src/compute-model-statistics/src/test/scala/VerifyComputeModelStatistics.scala
+++ b/src/compute-model-statistics/src/test/scala/VerifyComputeModelStatistics.scala
@@ -5,6 +5,7 @@ package com.microsoft.ml.spark
 
 import com.microsoft.ml.spark.TrainRegressorTestUtilities._
 import com.microsoft.ml.spark.TrainClassifierTestUtilities._
+import com.microsoft.ml.spark.metrics.MetricConstants
 import com.microsoft.ml.spark.schema.{CategoricalUtilities, SchemaConstants, SparkSchema}
 import org.apache.spark.ml.classification.LogisticRegression
 import org.apache.spark.ml.evaluation.BinaryClassificationEvaluator
@@ -66,7 +67,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assert(firstRow.getDouble(2) === 1.0)
     assert(firstRow.getDouble(3) === 0.0)
 
-    assert(evaluatedSchema == StructType(ComputeModelStatistics.regressionColumns.map(StructField(_, DoubleType))))
+    assert(evaluatedSchema == StructType(MetricConstants.regressionColumns.map(StructField(_, DoubleType))))
   }
 
   test("Evaluate a dataset with missing values") {
@@ -137,7 +138,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     val evaluatedData = new ComputeModelStatistics().transform(scoredDataset)
 
     val evaluatedSchema = new ComputeModelStatistics().transformSchema(scoredDataset.schema)
-    assert(evaluatedSchema == StructType(ComputeModelStatistics.classificationColumns.map(StructField(_, DoubleType))))
+    assert(evaluatedSchema == StructType(MetricConstants.classificationColumns.map(StructField(_, DoubleType))))
   }
 
   test("Verify computing statistics on generic spark ML estimators is supported") {
@@ -162,7 +163,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       .setLabelCol(labelColumn)
       .setScoredLabelsCol(scoredLabelsCol)
       .setScoresCol(scoresCol)
-      .setEvaluationMetric(ComputeModelStatistics.ClassificationMetrics)
+      .setEvaluationMetric(MetricConstants.ClassificationMetrics)
     val evaluatedData = cms.transform(scoredData)
     val firstRow = evaluatedData.select(col("accuracy"), col("precision"), col("recall"), col("AUC")).first()
     assert(firstRow.get(0).asInstanceOf[Double] === 1.0)
@@ -215,15 +216,15 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
 
     val overallAccuracy = (tp0 + tp1 + tp2) / total
     val evalRow = evaluatedData.first()
-    assert(evalRow.getAs[Double](ComputeModelStatistics.AccuracyColumnName) === overallAccuracy)
-    assert(evalRow.getAs[Double](ComputeModelStatistics.PrecisionColumnName) === overallAccuracy)
-    assert(evalRow.getAs[Double](ComputeModelStatistics.RecallColumnName) === overallAccuracy)
+    assert(evalRow.getAs[Double](MetricConstants.AccuracyColumnName) === overallAccuracy)
+    assert(evalRow.getAs[Double](MetricConstants.PrecisionColumnName) === overallAccuracy)
+    assert(evalRow.getAs[Double](MetricConstants.RecallColumnName) === overallAccuracy)
     val avgAccuracy = ((tp0 + tn0) / total + (tp1 + tn1) / total + (tp2 + tn2) / total) / numLabels
     val macroPrecision = (precision0 + precision1 + precision2) / numLabels
     val macroRecall = (recall0 + recall1 + recall2) / numLabels
-    assert(evalRow.getAs[Double](ComputeModelStatistics.AverageAccuracy) === avgAccuracy)
-    assert(evalRow.getAs[Double](ComputeModelStatistics.MacroAveragedPrecision) === macroPrecision)
-    assert(evalRow.getAs[Double](ComputeModelStatistics.MacroAveragedRecall) === macroRecall)
+    assert(evalRow.getAs[Double](MetricConstants.AverageAccuracy) === avgAccuracy)
+    assert(evalRow.getAs[Double](MetricConstants.MacroAveragedPrecision) === macroPrecision)
+    assert(evalRow.getAs[Double](MetricConstants.MacroAveragedRecall) === macroRecall)
   }
 
   test("validate AUC from compute model statistic and binary classification evaluator gives the same result") {

--- a/src/core/contracts/src/main/scala/Params.scala
+++ b/src/core/contracts/src/main/scala/Params.scala
@@ -174,3 +174,53 @@ trait HasFeaturesCol extends Wrappable {
   /** @group getParam */
   def getFeaturesCol: String = $(featuresCol)
 }
+
+trait HasScoredLabelsCol extends Wrappable {
+  /** The name of the scored labels column
+    * @group param
+    */
+  val scoredLabelsCol =
+    StringParam(this, "scoredLabelsCol",
+                "Scored labels column name, only required if using SparkML estimators")
+  /** @group setParam */
+  def setScoredLabelsCol(value: String): this.type = set(scoredLabelsCol, value)
+  /** @group getParam */
+  def getScoredLabelsCol: String = $(scoredLabelsCol)
+}
+
+trait HasScoresCol extends Wrappable {
+  /** The name of the scores column
+    * @group param
+    */
+  val scoresCol =
+    StringParam(this, "scoresCol",
+                "Scores or raw prediction column name, only required if using SparkML estimators")
+  /** @group setParam */
+  def setScoresCol(value: String): this.type = set(scoresCol, value)
+  /** @group getParam */
+  def getScoresCol: String = $(scoresCol)
+}
+
+trait HasScoredProbabilitiesCol extends Wrappable {
+  /** The name of the scored probabilities column
+    * @group param
+    */
+  val scoredProbabilitiesCol =
+    StringParam(this, "scoredProbabilitiesCol",
+                "Scored probabilities, usually calibrated from raw scores, only required if using SparkML estimators")
+  /** @group setParam */
+  def setScoredProbabilitiesCol(value: String): this.type = set(scoredProbabilitiesCol, value)
+  /** @group getParam */
+  def getScoredProbabilitiesCol: String = $(scoredProbabilitiesCol)
+}
+
+trait HasEvaluationMetric extends Wrappable {
+  val evaluationMetric: Param[String] =
+    StringParam(this, "evaluationMetric", "Metric to evaluate models with")
+
+  /** @group getParam */
+  def getEvaluationMetric: String = $(evaluationMetric)
+
+  /** @group setParam */
+  def setEvaluationMetric(value: String): this.type = set(evaluationMetric, value)
+}

--- a/src/core/metrics/build.sbt
+++ b/src/core/metrics/build.sbt
@@ -1,0 +1,5 @@
+// Explicitly prevent core/test code from depending on core sources
+//> DependsOn: core/test
+//> DependsOn: core/spark
+//> DependsOn: core/env
+//> DependsOn: core/schema

--- a/src/core/metrics/src/main/scala/MetricConstants.scala
+++ b/src/core/metrics/src/main/scala/MetricConstants.scala
@@ -1,0 +1,95 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.metrics
+
+/** Contains constants used by modules for metrics. */
+object MetricConstants {
+  // Regression metrics
+  val MseSparkMetric  = "mse"
+  val RmseSparkMetric = "rmse"
+  val R2SparkMetric   = "r2"
+  val MaeSparkMetric  = "mae"
+  val RegressionMetrics = "regression"
+
+  val regressionMetrics = Set(MseSparkMetric, RmseSparkMetric, R2SparkMetric,
+    MaeSparkMetric, RegressionMetrics)
+
+  // Binary Classification metrics
+  val AreaUnderROCMetric   = "areaUnderROC"
+  val AucSparkMetric       = "AUC"
+  val AccuracySparkMetric  = "accuracy"
+  val PrecisionSparkMetric = "precision"
+  val RecallSparkMetric    = "recall"
+  val ClassificationMetrics = "classification"
+
+  val classificationMetrics = Set(AreaUnderROCMetric, AucSparkMetric, AccuracySparkMetric,
+    PrecisionSparkMetric, RecallSparkMetric, ClassificationMetrics)
+
+  val AllSparkMetrics      = "all"
+
+  // Regression column names
+  val MseColumnName  = "mean_squared_error"
+  val RmseColumnName = "root_mean_squared_error"
+  val R2ColumnName   = "R^2"
+  val MaeColumnName  = "mean_absolute_error"
+
+  // Binary Classification column names
+  val AucColumnName = "AUC"
+
+  // Binary and Multiclass (micro-averaged) column names
+  val PrecisionColumnName = "precision"
+  val RecallColumnName    = "recall"
+  val AccuracyColumnName  = "accuracy"
+
+  // Multiclass Classification column names
+  val AverageAccuracy        = "average_accuracy"
+  val MacroAveragedRecall    = "macro_averaged_recall"
+  val MacroAveragedPrecision = "macro_averaged_precision"
+
+  // Metric to column name
+  val metricToColumnName = Map(AccuracySparkMetric -> AccuracyColumnName,
+    PrecisionSparkMetric -> PrecisionColumnName,
+    RecallSparkMetric    -> RecallColumnName,
+    MseSparkMetric       -> MseColumnName,
+    RmseSparkMetric      -> RmseColumnName,
+    R2SparkMetric        -> R2ColumnName,
+    MaeSparkMetric       -> MaeColumnName)
+
+  val classificationColumns = List(AccuracyColumnName, PrecisionColumnName, RecallColumnName)
+
+  val regressionColumns = List(MseColumnName, RmseColumnName, R2ColumnName, MaeColumnName)
+
+  val ClassificationEvaluationType = "Classification"
+  val EvaluationType = "evaluation_type"
+
+  val FpRateROCColumnName = "false_positive_rate"
+  val TpRateROCColumnName = "true_positive_rate"
+
+  val FpRateROCLog = "fpr"
+  val TpRateROCLog = "tpr"
+
+  val BinningThreshold = 1000
+
+  // Regression per instance metrics
+  val L1LossMetric  = "L1_loss"
+  val L2LossMetric  = "L2_loss"
+
+  val regressionPerInstanceMetrics = Set(RegressionMetrics)
+
+  // Classification per instance metrics
+  val LogLossMetric = "log_loss"
+
+  val classificationPerInstanceMetrics = Set(ClassificationMetrics)
+
+  val findBestModelMetrics =
+    Set(MetricConstants.MseSparkMetric,
+        MetricConstants.RmseSparkMetric,
+        MetricConstants.R2SparkMetric,
+        MetricConstants.MaeSparkMetric,
+        MetricConstants.AccuracySparkMetric,
+        MetricConstants.PrecisionSparkMetric,
+        MetricConstants.RecallSparkMetric,
+        MetricConstants.AucSparkMetric)
+
+}

--- a/src/core/metrics/src/main/scala/MetricUtils.scala
+++ b/src/core/metrics/src/main/scala/MetricUtils.scala
@@ -1,0 +1,61 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.metrics
+
+import com.microsoft.ml.spark.schema.SchemaConstants.MMLTag
+import com.microsoft.ml.spark.schema.{SchemaConstants, SparkSchema}
+import org.apache.spark.sql.types.{Metadata, MetadataUtilities, StructField, StructType}
+import org.apache.spark.ml.param._
+
+/** Utilities used by modules for metrics. */
+object MetricUtils {
+
+  def isClassificationMetric(metric: String): Boolean = {
+    if (MetricConstants.regressionMetrics.contains(metric)) false
+    else if (MetricConstants.classificationMetrics.contains(metric)) true
+    else throw new Exception("Invalid metric specified")
+  }
+
+  def getSchemaInfo(schema: StructType, labelCol: Option[String],
+                    evaluationMetric: String): (String, String, String) = {
+    val schemaInfo = tryGetSchemaInfo(schema)
+    if (schemaInfo.isDefined) {
+      schemaInfo.get
+    } else {
+      if (labelCol.isEmpty || evaluationMetric == MetricConstants.AllSparkMetrics) {
+        throw new Exception("Please score the model prior to evaluating")
+      }
+      ("custom model", labelCol.get,
+        if (isClassificationMetric(evaluationMetric))
+          SchemaConstants.ClassificationKind
+        else SchemaConstants.RegressionKind)
+    }
+  }
+
+  private def tryGetSchemaInfo(schema: StructType): Option[(String, String, String)] = {
+    // TODO: evaluate all models; for now, get first model name found
+    val firstModelName = schema.collectFirst {
+      case StructField(c, t, _, m) if getFirstModelName(m) != null && !getFirstModelName(m).isEmpty => {
+          getFirstModelName(m).get
+      }
+    }
+    if (firstModelName.isEmpty) None
+    else {
+      val modelName = firstModelName.get
+      val labelColumnName = SparkSchema.getLabelColumnName(schema, modelName)
+      val scoreValueKind = SparkSchema.getScoreValueKind(schema, modelName, labelColumnName)
+      Option((modelName, labelColumnName, scoreValueKind))
+    }
+  }
+
+  private def getFirstModelName(colMetadata: Metadata): Option[String] = {
+    if (!colMetadata.contains(MMLTag)) null
+    else {
+      val mlTagMetadata = colMetadata.getMetadata(MMLTag)
+      val metadataKeys = MetadataUtilities.getMetadataKeys(mlTagMetadata)
+      metadataKeys.find(key => key.startsWith(SchemaConstants.ScoreModelPrefix))
+    }
+  }
+
+}

--- a/src/find-best-model/src/main/scala/EvaluationUtils.scala
+++ b/src/find-best-model/src/main/scala/EvaluationUtils.scala
@@ -3,54 +3,12 @@
 
 package com.microsoft.ml.spark
 
+import com.microsoft.ml.spark.metrics.MetricConstants
 import com.microsoft.ml.spark.schema.SchemaConstants
-import org.apache.spark.ml.classification.{ClassificationModel, Classifier, ProbabilisticClassificationModel}
-import org.apache.spark.ml.{Estimator, PipelineStage, RegressionUtils, Transformer}
+import org.apache.spark.ml.classification.{ClassificationModel, Classifier}
+import org.apache.spark.ml.{PipelineStage, RegressionUtils, Transformer}
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.regression._
-
-trait HasEvaluationMetric extends Wrappable {
-
-  /** Metric to evaluate the models with. Default is "all"
-    *
-    * The metrics that can be chosen are:
-    *
-    *   For Binary Classifiers:
-    *     - AreaUnderROC
-    *     - AUC
-    *     - accuracy
-    *     - precision
-    *     - recall
-    *
-    *   For Regression Classifiers:
-    *     - mse
-    *     - rmse
-    *     - r2
-    *     - mae
-    *
-    *   Or, for either type of classifier:
-    *     - all - This will report all the relevant metrics
-    *
-    * @group param
-    */
-  val evaluationMetric: Param[String] = StringParam(this, "evaluationMetric", "Metric to evaluate models with",
-    (s: String) => Set(ComputeModelStatistics.MseSparkMetric,
-      ComputeModelStatistics.RmseSparkMetric,
-      ComputeModelStatistics.R2SparkMetric,
-      ComputeModelStatistics.MaeSparkMetric,
-      ComputeModelStatistics.AccuracySparkMetric,
-      ComputeModelStatistics.PrecisionSparkMetric,
-      ComputeModelStatistics.RecallSparkMetric,
-      ComputeModelStatistics.AucSparkMetric) contains s)
-  /** @group getParam */
-  def getEvaluationMetric: String = $(evaluationMetric)
-  /** @group setParam */
-  def setEvaluationMetric(value: String): this.type = set(evaluationMetric, value)
-
-  // Set default evaluation metric to accuracy
-  setDefault(evaluationMetric -> ComputeModelStatistics.AccuracySparkMetric)
-
-}
 
 object EvaluationUtils {
   val modelTypeUnsupportedErr = "Model type not supported for evaluation"
@@ -83,17 +41,17 @@ object EvaluationUtils {
     val chooseLowest = Ordering.Double.reverse
     val (evaluationMetricColumnName, operator): (String, Ordering[Double]) = modelType match {
       case SchemaConstants.RegressionKind => evaluationMetric match {
-        case ComputeModelStatistics.MseSparkMetric  => (ComputeModelStatistics.MseColumnName,  chooseLowest)
-        case ComputeModelStatistics.RmseSparkMetric => (ComputeModelStatistics.RmseColumnName, chooseLowest)
-        case ComputeModelStatistics.R2SparkMetric   => (ComputeModelStatistics.R2ColumnName,   chooseHighest)
-        case ComputeModelStatistics.MaeSparkMetric  => (ComputeModelStatistics.MaeColumnName,  chooseLowest)
+        case MetricConstants.MseSparkMetric  => (MetricConstants.MseColumnName,  chooseLowest)
+        case MetricConstants.RmseSparkMetric => (MetricConstants.RmseColumnName, chooseLowest)
+        case MetricConstants.R2SparkMetric   => (MetricConstants.R2ColumnName,   chooseHighest)
+        case MetricConstants.MaeSparkMetric  => (MetricConstants.MaeColumnName,  chooseLowest)
         case _ => throw new Exception("Metric is not supported for regressors")
       }
       case SchemaConstants.ClassificationKind => evaluationMetric match {
-        case ComputeModelStatistics.AucSparkMetric       => (ComputeModelStatistics.AucColumnName, chooseHighest)
-        case ComputeModelStatistics.PrecisionSparkMetric => (ComputeModelStatistics.PrecisionColumnName, chooseHighest)
-        case ComputeModelStatistics.RecallSparkMetric    => (ComputeModelStatistics.RecallColumnName, chooseHighest)
-        case ComputeModelStatistics.AccuracySparkMetric  => (ComputeModelStatistics.AccuracyColumnName, chooseHighest)
+        case MetricConstants.AucSparkMetric       => (MetricConstants.AucColumnName, chooseHighest)
+        case MetricConstants.PrecisionSparkMetric => (MetricConstants.PrecisionColumnName, chooseHighest)
+        case MetricConstants.RecallSparkMetric    => (MetricConstants.RecallColumnName, chooseHighest)
+        case MetricConstants.AccuracySparkMetric  => (MetricConstants.AccuracyColumnName, chooseHighest)
         case _ => throw new Exception("Metric is not supported for classifiers")
       }
       case _ => throw new Exception("Model type not supported for evaluation")

--- a/src/find-best-model/src/test/scala/VerifyFindBestModel.scala
+++ b/src/find-best-model/src/test/scala/VerifyFindBestModel.scala
@@ -3,11 +3,13 @@
 
 package com.microsoft.ml.spark
 
-import org.apache.spark.ml.util.{MLReadable, MLWritable}
+import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.ml.{PipelineStage, Transformer}
+import org.apache.spark.ml.Transformer
 import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
 import org.apache.commons.io.FileUtils
+
+import com.microsoft.ml.spark.metrics.MetricConstants
 
 class VerifyFindBestModel extends EstimatorFuzzing[FindBestModel]{
 
@@ -36,7 +38,7 @@ class VerifyFindBestModel extends EstimatorFuzzing[FindBestModel]{
     val model = randomForestClassifier.fit(dataset)
     val findBestModel = new FindBestModel()
       .setModels(Array(model.asInstanceOf[Transformer], model.asInstanceOf[Transformer]))
-      .setEvaluationMetric(ComputeModelStatistics.AccuracySparkMetric)
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
     val bestModel = findBestModel.fit(dataset)
     bestModel.transform(dataset)
   }
@@ -48,7 +50,7 @@ class VerifyFindBestModel extends EstimatorFuzzing[FindBestModel]{
 
     val findBestModel = new FindBestModel()
       .setModels(Array(model.asInstanceOf[Transformer], model.asInstanceOf[Transformer]))
-      .setEvaluationMetric(ComputeModelStatistics.AucSparkMetric)
+      .setEvaluationMetric(MetricConstants.AucSparkMetric)
     val bestModel = findBestModel.fit(dataset)
 
     val myModelName = "testEvalModel"
@@ -72,7 +74,7 @@ class VerifyFindBestModel extends EstimatorFuzzing[FindBestModel]{
 
     val findBestModel = new FindBestModel()
       .setModels(Array(model1.asInstanceOf[Transformer], model2, model3, model4, model5))
-      .setEvaluationMetric(ComputeModelStatistics.AucSparkMetric)
+      .setEvaluationMetric(MetricConstants.AucSparkMetric)
     val bestModel = findBestModel.fit(dataset)
     // validate schema is as expected
     assert(bestModel.getAllModelMetrics.schema ==
@@ -96,5 +98,5 @@ class VerifyFindBestModel extends EstimatorFuzzing[FindBestModel]{
     val model = randomForestClassifier.fit(createMockDataset)
     new FindBestModel()
       .setModels(Array(model, model))
-      .setEvaluationMetric(ComputeModelStatistics.AccuracySparkMetric)}, createMockDataset))
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)}, createMockDataset))
 }

--- a/src/tune-hyperparameters/src/main/scala/TuneHyperparameters.scala
+++ b/src/tune-hyperparameters/src/main/scala/TuneHyperparameters.scala
@@ -6,12 +6,13 @@ package com.microsoft.ml.spark
 import java.util.concurrent._
 
 import com.google.common.util.concurrent.{MoreExecutors, ThreadFactoryBuilder}
+import com.microsoft.ml.spark.metrics.MetricConstants
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml._
-import org.apache.spark.ml.classification.{ClassificationModel}
+import org.apache.spark.ml.classification.ClassificationModel
 import org.apache.spark.ml.regression.RegressionModel
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.sql._
@@ -101,7 +102,8 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
     }
   }
 
-  /** Finds the best model
+  /** Tunes model hyperparameters for given number of runs and returns the best model
+    * found based on evaluation metric.
     *
     * @param dataset The input dataset to train.
     * @return The trained classification model.
@@ -149,16 +151,16 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
                   .setLabelCol(classificationModel.getLabelCol)
                   .setScoredLabelsCol(classificationModel.getPredictionCol)
                   .setScoresCol(classificationModel.getRawPredictionCol)
-                if (getEvaluationMetric == ComputeModelStatistics.AllSparkMetrics)
-                  evaluator.setEvaluationMetric(ComputeModelStatistics.ClassificationMetrics)
+                if (getEvaluationMetric == MetricConstants.AllSparkMetrics)
+                  evaluator.setEvaluationMetric(MetricConstants.ClassificationMetrics)
               }
               case regressionModel: RegressionModel[_, _] => {
                 logDebug(s"Evaluating SparkML ${model.uid} regression model.")
                 evaluator
                   .setLabelCol(regressionModel.getLabelCol)
                   .setScoredLabelsCol(regressionModel.getPredictionCol)
-                if (getEvaluationMetric == ComputeModelStatistics.AllSparkMetrics)
-                  evaluator.setEvaluationMetric(ComputeModelStatistics.RegressionMetrics)
+                if (getEvaluationMetric == MetricConstants.AllSparkMetrics)
+                  evaluator.setEvaluationMetric(MetricConstants.RegressionMetrics)
               }
             }
             val metrics = evaluator.transform(scoredDataset)

--- a/src/tune-hyperparameters/src/test/scala/VerifyTuneHyperparameters.scala
+++ b/src/tune-hyperparameters/src/test/scala/VerifyTuneHyperparameters.scala
@@ -11,6 +11,8 @@ import org.apache.spark.sql.DataFrame
 
 import scala.collection.mutable.ListBuffer
 
+import com.microsoft.ml.spark.metrics.MetricConstants
+
 /** Tests to validate the functionality of Tune Hyperparameters module. */
 class VerifyTuneHyperparameters extends Benchmarks {
 
@@ -140,7 +142,7 @@ class VerifyTuneHyperparameters extends Benchmarks {
 
     new TuneHyperparameters()
       .setModels(models.toArray)
-      .setEvaluationMetric(ComputeModelStatistics.AccuracySparkMetric)
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
       .setNumFolds(4)
       .setNumRuns(models.length * 3)
       .setParallelism(1)
@@ -168,7 +170,7 @@ class VerifyTuneHyperparameters extends Benchmarks {
       val randomSpace = new RandomSpace(hyperParams.toArray)
       new TuneHyperparameters()
         .setModels(models.toArray)
-        .setEvaluationMetric(ComputeModelStatistics.AccuracySparkMetric)
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
         .setNumFolds(2)
         .setNumRuns(2)
         .setParallelism(1)


### PR DESCRIPTION
Updating per instance stats module to work for spark ML estimators in addition to TrainClassifier and TrainRegressor.
Also doing some minor refactoring and removing duplicate code.