### PR TITLE
Fixing random performance bug in CMS due to catalyst issue

### DIFF
--- a/notebooks/samples/104 - Price Prediction Regression Auto Imports.ipynb
+++ b/notebooks/samples/104 - Price Prediction Regression Auto Imports.ipynb
@@ -280,8 +280,7 @@
     "* Mean absolute error\n",
     "\n",
     "Use the `ComputeModelStatistics` API to compute basic statistics for\n",
-    "the Poisson and the Random Forest models.  Note that these computations\n",
-    "can take a relatively long time, and they are therefore commented out."
+    "the Poisson and the Random Forest models."
    ]
   },
   {
@@ -290,11 +289,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Uncomment the following to evaluate the PoissonRegressor using ComputeStatistics\n",
-    "# from mmlspark import ComputeModelStatistics\n",
-    "# poissonMetrics = ComputeModelStatistics().transform(poissonPrediction)\n",
-    "# print(\"Poisson Metrics\")\n",
-    "# poissonMetrics.toPandas()"
+    "from mmlspark import ComputeModelStatistics\n",
+    "poissonMetrics = ComputeModelStatistics().transform(poissonPrediction)\n",
+    "print(\"Poisson Metrics\")\n",
+    "poissonMetrics.toPandas()"
    ]
   },
   {
@@ -303,17 +301,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# and uncomment the following to evaluate the RandomForestRegressor\n",
-    "# randomForestMetrics = ComputeModelStatistics().transform(randomForestPrediction)\n",
-    "# print(\"Random Forest Metrics\")\n",
-    "# randomForestMetrics.toPandas()"
+    "randomForestMetrics = ComputeModelStatistics().transform(randomForestPrediction)\n",
+    "print(\"Random Forest Metrics\")\n",
+    "randomForestMetrics.toPandas()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of the above, we evaluate some predictions with `poissonPrediction`:"
+    "We can also compute per instance statistics for `poissonPrediction`:"
    ]
   },
   {

--- a/src/compute-model-statistics/src/main/scala/ComputeModelStatistics.scala
+++ b/src/compute-model-statistics/src/main/scala/ComputeModelStatistics.scala
@@ -257,7 +257,10 @@ class ComputeModelStatistics(override val uid: String) extends Transformer with 
   private def selectAndCastToDF(dataset: Dataset[_],
                                 predictionColumnName: String,
                                 labelColumnName: String): DataFrame = {
+    // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
+    // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
     dataset.select(col(predictionColumnName), col(labelColumnName).cast(DoubleType))
+      .cache()
       .na
       .drop(Array(predictionColumnName, labelColumnName))
   }
@@ -278,7 +281,10 @@ class ComputeModelStatistics(override val uid: String) extends Transformer with 
                                      scoredLabelsColumnName: String,
                                      levelsToIndexMap: Map[Any, Double]): RDD[(Double, Double)] = {
     // Calculate confusion matrix and output it as DataFrame
+    // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
+    // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
     dataset.select(col(scoredLabelsColumnName), col(labelColumnName))
+      .cache()
       .na
       .drop(Array(scoredLabelsColumnName, labelColumnName))
       .rdd
@@ -303,7 +309,10 @@ class ComputeModelStatistics(override val uid: String) extends Transformer with 
                          labelColumnName: String,
                          scoresColumnName: String,
                          levelsToIndexMap: Map[Any, Double]): RDD[(Double, Double)] = {
+    // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
+    // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
     dataset.select(col(scoresColumnName), col(labelColumnName))
+      .cache()
       .na
       .drop(Array(scoresColumnName, labelColumnName))
       .rdd


### PR DESCRIPTION
CMS sometimes gets randomly stuck in catalyst when dropping missing values if a specific sequence of estimators is run before it.  Caching the data resolves the issues with catalyst.  This looks like a bug in spark's catalyst which might have been already resolved in future versions of spark.

This resolves issue #186 