### PR TITLE
Improve branch builds

### DIFF
--- a/tools/build-pr/checkout
+++ b/tools/build-pr/checkout
@@ -13,15 +13,18 @@ _ cp -a "$TOOLSDIR/build-pr" "$PRDIR/build-pr"
 
 if [[ "$BUILDPR" = "" ]]; then exit 0; fi
 
-echo "##[section] PR Build for #$BUILDPR"
-
+printf "========================================\n"
+if [[ "$BUILDPR" = */*/* ]]; then
+  echo "##[section] Branch Build for $BUILDPR"
+else
+  echo "##[section] PR Build for #$BUILDPR"
+fi
 get_pr_info
 repourl="https://github.com/$REPO"
+printf '  repo: %s\n  ref: %s\n  sha1: %s\n' "$REPO" "$REF" "$SHA1"
+printf "========================================\n"
 
-printf 'PR BUILD for #%s\n  repo: %s\n  ref: %s\n  sha1: %s\n' \
-       "$BUILDPR" "$REPO" "$REF" "$SHA1"
-
-git checkout "master" > /dev/null 2>&1
+git checkout -f "master" > /dev/null 2>&1
 oldbr="$(git for-each-ref --format="%(refname:short)" "refs/heads/pr-*")"
 if [[ -n "$oldbr" ]]; then git branch -D "$oldbr"; fi
 
@@ -30,12 +33,15 @@ post_status "pending" "$text"
 post_comment "$text"
 
 _get_T
-git fetch "https://$T@github.com/$REPO" "$REF:refs/heads/pr-$BUILDPR"
-git checkout "pr-$BUILDPR"
+bname="pr-$BUILDPR"; bname="${bname//\//-}"
+git fetch "https://$T@github.com/$REPO" "$REF:refs/heads/$bname"
+git checkout "$bname"
 git reset --hard "$SHA1"
 
 # useful info in build
-{ printf '### This is a build for %s, changes:\n\n' "[github PR #$BUILDPR]($GURL)"
+{ if [[ "$BUILDPR" = */*/* ]]; then txt="Github Branch $BUILDPR"
+  else txt="Github PR #$BUILDPR"; fi
+  printf '### This is a build for %s, changes:\n\n' "[$txt]($GURL)"
   git log --format="* [[%h]($repourl/commit/%H)] [%aN](mailto:%aE) %s" \
       "origin/master..$SHA1"
   printf '\n---\n'

--- a/tools/build-pr/report
+++ b/tools/build-pr/report
@@ -22,7 +22,7 @@ case "${AGENT_JOBSTATUS,,}" in
   ( *         ) icon+="1.svg"; box="![$AGENT_JOBSTATUS]($icon) Unknown"; state="error" ;;
 esac
 
-if [[ "$BUILDPR" = "" ]]; then
+if [[ -z "$BUILDPR" ]]; then
   _ az storage blob copy start --account-name "$MAIN_STORAGE" \
        --destination-container "icons" --destination-blob "BuildStatus.png" \
        --source-uri "$icon"
@@ -31,7 +31,7 @@ fi
 
 get_pr_info
 
-if [[ "$BUILDPR" = "0" ]]; then exit; fi
+if [[ "$BUILDPR" = */*/* ]]; then exit; fi
 
 text="The build has ${AGENT_JOBSTATUS,,}.  (${SHA1:0:8})"; more_text=""
 post_status "$state" "$text"

--- a/tools/misc/container-gc
+++ b/tools/misc/container-gc
@@ -165,10 +165,12 @@ get-ver-info() (
   jq --arg b "$binfo" '. + {buildinfo: $b}' \
      < "$info" > "$info-new"; mv "$info-new" "$info"
   #
-  rx="\n#+ [^\n]* build [^\n]*github PR #([0-9]+)"
-  rx=$'\n'"#+ [^"$'\n'"]* build [^"$'\n'"]*github PR #([0-9]+)"
-  if [[ "$binfo" =~ $rx ]]; then pr="${BASH_REMATCH[1]}"; else pr=""; fi
-  jq --arg pr "$pr" '. + {github_pr: $pr}' \
+  pr_rx=$'\n'"#+ [^"$'\n'"]* build [^"$'\n'"]*[Gg]ithub PR #([0-9]+)"
+  br_rx=$'\n'"#+ [^"$'\n'"]* build [^"$'\n'"]*[Gg]ithub [Bb]ranch ([^][]+)"
+  if   [[ "$binfo" =~ $pr_rx ]]; then pr="${BASH_REMATCH[1]}" br=""
+  elif [[ "$binfo" =~ $br_rx ]]; then br="${BASH_REMATCH[1]}" pr=""
+  else pr="" br=""; fi
+  jq --arg pr "$pr" --arg br "$br" '. + {github_pr: $pr, github_br: $br}' \
      < "$info" > "$info-new"; mv "$info-new" "$info"
   #
   jq --argjson now "$(date +"%s")" --arg labelpath "$v/.label" \
@@ -183,7 +185,7 @@ get-ver-info() (
 )
 
 show-all-oneline() {
-  local v times t1 t2 info pr; now="$(date +"%s")"
+  local v times t1 t2 info pr br; now="$(date +"%s")"
   printf "\n"
   for v in "${all[@]}"; do
     if [[ -r "$cachedir/$v" && ! -s "$cachedir/$v" ]]; then continue; fi
@@ -193,11 +195,13 @@ show-all-oneline() {
     printf ' %-16s' "$(show-time-range "${times%:*}" "${times#*:}")"
     info="$(jq -r '.label' < "$cachedir/$v")"
     pr="$(jq -r '.github_pr' < "$cachedir/$v")"
+    br="$(jq -r '.github_br' < "$cachedir/$v")"
     if [[ -n "$pr" ]]; then
       if [[ "$github_prs" = *" $pr "* ]]
       then pr="PR #$pr"; else pr="Closed PR #$pr"; fi
       info="$pr${info:+"; "}$info"
     fi
+    if [[ -n "$br" ]]; then info="Branch $br${info:+"; "}$info"; fi
     if [[ -z "$info" ]]; then printf '\n'
     else printf ' [%s]\n' "$info"; fi
   done


### PR DESCRIPTION
It is now possible to use `<user>/<repo>/<branch>` for the "BuildPR"
field.  These were called "private builds" when implemented a few
commits ago as a quick hack.