### PR TITLE
Fixing CMS multiclass performance and adding tests

### DIFF
--- a/src/core/metrics/src/main/scala/MetricConstants.scala
+++ b/src/core/metrics/src/main/scala/MetricConstants.scala
@@ -47,6 +47,8 @@ object MetricConstants {
   val MacroAveragedRecall    = "macro_averaged_recall"
   val MacroAveragedPrecision = "macro_averaged_precision"
 
+  val ConfusionMatrix = "confusion_matrix"
+
   // Metric to column name
   val metricToColumnName = Map(AccuracySparkMetric -> AccuracyColumnName,
     PrecisionSparkMetric -> PrecisionColumnName,


### PR DESCRIPTION
Improving performance on multiclass data when there is a large number of labels in the dataset