### PR TITLE
Remove libraries that are no longer needed

### DIFF
--- a/tools/config.sh
+++ b/tools/config.sh
@@ -102,7 +102,6 @@ INSTALLATIONS=(
   sha256: "2ed7917d426025d7dd722c7d7fda5f55e6bbec7a293a3bfc4cb163c10b4b27f6"
   exes:   "cntk"
   vers:   "cat version.txt|CNTK-<{dashver}>"
-  prereq: "has_libs libpng12.so.0 libjasper.so.1|libpng12 and libjasper1 are required"
   bindir: "cntk/bin"
   where:  "devel build"
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,8 +13,7 @@ RUN : '==== create a user (and also hide the random hostname in the prompt)' \
  && useradd -c "Microsoft ML for Apache Spark" -U -G root -d "$HOME" -m "$USER" \
  && : '==== install needed packages' \
  && apt-get update --fix-missing \
- && apt-get install -y curl unzip bzip2 libopenmpi1.10 libgomp1 libunwind8 \
-                       libtiff5 libpng12-0 libjasper1 \
+ && apt-get install -y curl unzip bzip2 \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR $HOME

--- a/tools/docker/Dockerfile-plus
+++ b/tools/docker/Dockerfile-plus
@@ -7,8 +7,9 @@ USER root:root
 
 RUN apt-get update --fix-missing \
  && apt-get install -y \
-      libc6 libcurl3 libgcc1 gcc libgssapi-krb5-2 libicu55 liblttng-ust0 \
-      libssl1.0.0 libstdc++6 libuuid1 zlib1g liblldb-3.6 libxml++2.6-2v5 \
+      libc6 libcurl3 libgcc1 gcc libopenmpi1.10 libgomp1 libunwind8 \
+      libssl1.0.0 libgssapi-krb5-2 libicu55 liblttng-ust0 \
+      libstdc++6 libuuid1 zlib1g liblldb-3.6 libxml++2.6-2v5 \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER $USER:$USER

--- a/tools/hdi/install-mmlspark.sh
+++ b/tools/hdi/install-mmlspark.sh
@@ -41,7 +41,9 @@ get_primary_headnode() {
 # Run on all nodes
 
 # Install prerequisites
-apt-get install -y openmpi-bin libunwind8 libpng12-0 libjasper1
+# (The following are no longer needed, leaving a comment in case
+# something similar will be needed in the future.)
+# apt-get install -y openmpi-bin libunwind8 libpng12-0 libjasper1
 
 # Install CNTK in all environments
 for env in "${CONDA_ENVS[@]}"; do


### PR DESCRIPTION
These libraries were mainly needed for CNTK which didn't have them, but
it was fixed in v2.4, so they are no longer needed.  (Still needs to be
done for the GPU version, when it's bumped to 2.4.)

Leave `libopenmpi1.10`, `libgomp1`, and `libunwind8` in the plus image, in
case it's needed there.