### PR TITLE
Add missing import length in PySpark Serving Docco

### DIFF
--- a/docs/mmlspark-serving.md
+++ b/docs/mmlspark-serving.md
@@ -26,7 +26,7 @@
    ```python
    import mmlspark
    import pyspark
-   from pyspark.sql.functions import udf, col
+   from pyspark.sql.functions import udf, col, length
 
    serving_source = "org.apache.spark.sql.execution.streaming.HTTPSourceProvider"
    serving_sink = "org.apache.spark.sql.execution.streaming.HTTPSinkProvider"


### PR DESCRIPTION
Adds the missing import which completes hello world example for pyspark serving