### PR TITLE
Improving performance of LightGBM for cluster with multiple cores per executor

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMParams.scala
+++ b/src/lightgbm/src/main/scala/LightGBMParams.scala
@@ -66,8 +66,13 @@ trait LightGBMParams extends MMLParams {
   def getMaxDepth: Int = $(maxDepth)
   def setMaxDepth(value: Int): this.type = set(maxDepth, value)
 
-  val minSumHessianInLeaf = DoubleParam(this, "minSumHessianInLeaf", "minimal sum hessian in one leaf", 1e-3)
+  val minSumHessianInLeaf = DoubleParam(this, "minSumHessianInLeaf", "Minimal sum hessian in one leaf", 1e-3)
 
   def getMinSumHessianInLeaf: Double = $(minSumHessianInLeaf)
   def setMinSumHessianInLeaf(value: Double): this.type = set(minSumHessianInLeaf, value)
+
+  val timeout = DoubleParam(this, "timeout", "Timeout in seconds", 30)
+
+  def getTimeout: Double = $(timeout)
+  def setTimeout(value: Double): this.type = set(timeout, value)
 }


### PR DESCRIPTION
We now determine the number of CPUs per executor (where 1 executor = 1 JVM).
On the driver, we start a separate thread prior to calling LightGBM train which waits to receive the (host,port) from (# executors X # cores) workers.
Prior to network init, on each of the workers we allocate a port and send it to the driver thread.
The driver thread receives all ports, aggregates, and then sends back the result so it can be used for network init.
This resolves several issues - 
1.) we ensure that the ports selected are open (we find only "open" ports and bind to them)
2.) we discover the number of CPUs per executor (per JVM) and use that - and all workers now request a port
3.) better logging to detect problems

This resolves issue: https://github.com/Azure/mmlspark/issues/292
