### PR TITLE
LightGBM model save model function

### DIFF
--- a/src/lightgbm/src/main/python/LightGBMClassifier.py
+++ b/src/lightgbm/src/main/python/LightGBMClassifier.py
@@ -1,0 +1,32 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import sys
+from pyspark import SQLContext
+from pyspark import SparkContext
+
+if sys.version >= '3':
+    basestring = str
+
+from mmlspark._LightGBMClassifier import _LightGBMClassifier
+from mmlspark._LightGBMClassifier import M
+from pyspark.ml.common import inherit_doc
+
+@inherit_doc
+class LightGBMClassifier(_LightGBMClassifier):
+    def _create_model(self, java_model):
+        model = LightGBMClassificationModel()
+        model._java_obj = java_model
+        model._transfer_params_from_java()
+        return model
+
+@inherit_doc
+class LightGBMClassificationModel(M):
+    def saveNativeModel(self, sparkSession, filename):
+        """
+        Save the booster as string format to a local or WASB remote location.
+        """
+        ctx = SparkContext.getOrCreate()
+        sql_ctx = SQLContext.getOrCreate(ctx)
+        jsession = sql_ctx.sparkSession._jsparkSession
+        self._java_obj.saveNativeModel(jsession, filename)

--- a/src/lightgbm/src/main/scala/LightGBMBooster.scala
+++ b/src/lightgbm/src/main/scala/LightGBMBooster.scala
@@ -6,6 +6,7 @@ package com.microsoft.ml.spark
 import com.microsoft.ml.lightgbm._
 import com.microsoft.ml.spark.LightGBMUtils.{intToPtr, newDoubleArray, newIntArray}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector}
+import org.apache.spark.sql.SparkSession
 
 /** Represents a LightGBM Booster learner
   * @param model The string serialized representation of the learner
@@ -137,5 +138,14 @@ class LightGBMBooster(val model: String) extends Serializable {
         "Booster merge")
     }
     new LightGBMBooster(model)
+  }
+
+  def saveNativeModel(session: SparkSession, filename: String): Unit = {
+    if (filename == null || filename.isEmpty()) {
+      throw new IllegalArgumentException("filename should not be empty or null.")
+    }
+
+    val rdd = session.sparkContext.parallelize(Seq(model))
+    rdd.coalesce(1).saveAsTextFile(filename)
   }
 }

--- a/src/lightgbm/src/main/scala/LightGBMClassifier.scala
+++ b/src/lightgbm/src/main/scala/LightGBMClassifier.scala
@@ -19,6 +19,7 @@ object LightGBMClassifier extends DefaultParamsReadable[LightGBMClassifier]
   * For parameter information see here: https://github.com/Microsoft/LightGBM/blob/master/docs/Parameters.rst
   * @param uid The unique ID.
   */
+@InternalWrapper
 class LightGBMClassifier(override val uid: String)
   extends ProbabilisticClassifier[Vector, LightGBMClassifier, LightGBMClassificationModel]
   with LightGBMParams {
@@ -56,6 +57,7 @@ class LightGBMClassifier(override val uid: String)
 }
 
 /** Model produced by [[LightGBMClassifier]]. */
+@InternalWrapper
 class LightGBMClassificationModel(
   override val uid: String, model: LightGBMBooster, labelColName: String,
   featuresColName: String, predictionColName: String, probColName: String,
@@ -100,6 +102,10 @@ class LightGBMClassificationModel(
   override def objectsToSave: List[Any] =
     List(uid, model, getLabelCol, getFeaturesCol, getPredictionCol,
          getProbabilityCol, getRawPredictionCol, thresholdValues)
+
+  def saveNativeModel(session: SparkSession, filename: String): Unit = {
+    model.saveNativeModel(session, filename)
+  }
 }
 
 object LightGBMClassificationModel extends ConstructorReadable[LightGBMClassificationModel]


### PR DESCRIPTION
This PR is to implement the functionality of save_model() for LightGBM model's booster. It serialize the model into the string representation the same way as scikit-learn implememtation (https://github.com/Microsoft/LightGBM).

When calling save_booster() from pyspark or saveBooster() from scala, the filename could be either local or WASB URI.

This should address Issue #294 