### PR TITLE
Remove LightGBMBooster's mergeModels function

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMBooster.scala
+++ b/src/lightgbm/src/main/scala/LightGBMBooster.scala
@@ -130,16 +130,6 @@ class LightGBMBooster(val model: String) extends Serializable {
     lightgbmlib.voidpp_value(boosterOutPtr)
   }
 
-  def mergeModels(newModel: LightGBMBooster): LightGBMBooster = {
-    // Merges models to first handle
-    if (model != null) {
-      LightGBMUtils.validate(
-        lightgbmlib.LGBM_BoosterMerge(getModel(), newModel.getModel()),
-        "Booster merge")
-    }
-    new LightGBMBooster(model)
-  }
-
   def saveNativeModel(session: SparkSession, filename: String): Unit = {
     if (filename == null || filename.isEmpty()) {
       throw new IllegalArgumentException("filename should not be empty or null.")


### PR DESCRIPTION
Discussed in https://github.com/Azure/mmlspark/issues/315, the merge function doesn't need anymore. Would better to remove it.