### PR TITLE
fixing copy method and verifying LGBM can be run with train TrainValidationSplit

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMClassifier.scala
+++ b/src/lightgbm/src/main/scala/LightGBMClassifier.scala
@@ -104,7 +104,8 @@ class LightGBMClassificationModel(
   }
 
   override def copy(extra: ParamMap): LightGBMClassificationModel =
-    defaultCopy(extra)
+    new LightGBMClassificationModel(uid, model, labelColName, featuresColName, predictionColName, probColName,
+      rawPredictionColName, thresholdValues)
 
   override val ttag: TypeTag[LightGBMClassificationModel] =
     typeTag[LightGBMClassificationModel]

--- a/src/lightgbm/src/main/scala/LightGBMRegressor.scala
+++ b/src/lightgbm/src/main/scala/LightGBMRegressor.scala
@@ -103,7 +103,8 @@ class LightGBMRegressionModel(override val uid: String, model: LightGBMBooster, 
     model.score(features, false)
   }
 
-  override def copy(extra: ParamMap): LightGBMRegressionModel = defaultCopy(extra)
+  override def copy(extra: ParamMap): LightGBMRegressionModel =
+    new LightGBMRegressionModel(uid, model, labelColName, featuresColName, predictionColName)
 
   override val ttag: TypeTag[LightGBMRegressionModel] = typeTag[LightGBMRegressionModel]
 


### PR DESCRIPTION
fixing copy method and verifying LGBM can be run with train TrainValidationSplit
this resolves issue #329 
Note the copy doesn't actually do anything - it is just needed because we don't have a constructor that takes in only a uid and nothing else (which spark transformers all have).  But this doesn't actually make sense to do, as none of the parameters on the model should be modifiable.