### PR TITLE
Added params writable and readable to lightGBM models

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMClassifier.scala
+++ b/src/lightgbm/src/main/scala/LightGBMClassifier.scala
@@ -25,7 +25,7 @@ object LightGBMClassifier extends DefaultParamsReadable[LightGBMClassifier]
 @InternalWrapper
 class LightGBMClassifier(override val uid: String)
   extends ProbabilisticClassifier[Vector, LightGBMClassifier, LightGBMClassificationModel]
-  with LightGBMParams {
+  with LightGBMParams with DefaultParamsWritable {
   def this() = this(Identifiable.randomUID("LightGBMClassifier"))
 
   /** Trains the LightGBM Classification model.
@@ -73,7 +73,7 @@ class LightGBMClassificationModel(
   featuresColName: String, predictionColName: String, probColName: String,
   rawPredictionColName: String, thresholdValues: Option[Array[Double]])
     extends ProbabilisticClassificationModel[Vector, LightGBMClassificationModel]
-    with ConstructorWritable[LightGBMClassificationModel] {
+    with ConstructorWritable[LightGBMClassificationModel] with DefaultParamsWritable {
 
   // Update the underlying Spark ML params
   // (for proper serialization to work we put them on constructor instead of using copy as in Spark ML)
@@ -120,3 +120,4 @@ class LightGBMClassificationModel(
 }
 
 object LightGBMClassificationModel extends ConstructorReadable[LightGBMClassificationModel]
+  with DefaultParamsReadable[LightGBMClassificationModel]

--- a/src/lightgbm/src/main/scala/LightGBMRegressor.scala
+++ b/src/lightgbm/src/main/scala/LightGBMRegressor.scala
@@ -36,7 +36,7 @@ object LightGBMRegressor extends DefaultParamsReadable[LightGBMRegressor]
   */
 class LightGBMRegressor(override val uid: String)
   extends BaseRegressor[Vector, LightGBMRegressor, LightGBMRegressionModel]
-    with LightGBMParams {
+    with LightGBMParams with DefaultParamsWritable {
   def this() = this(Identifiable.randomUID("LightGBMRegressor"))
 
   val alpha = DoubleParam(this, "alpha", "parameter for Huber loss and Quantile regression", 0.9)
@@ -91,7 +91,7 @@ class LightGBMRegressor(override val uid: String)
 class LightGBMRegressionModel(override val uid: String, model: LightGBMBooster, labelColName: String,
                                   featuresColName: String, predictionColName: String)
   extends RegressionModel[Vector, LightGBMRegressionModel]
-    with ConstructorWritable[LightGBMRegressionModel] {
+    with ConstructorWritable[LightGBMRegressionModel] with DefaultParamsWritable {
 
   // Update the underlying Spark ML params
   // (for proper serialization to work we put them on constructor instead of using copy as in Spark ML)
@@ -112,3 +112,4 @@ class LightGBMRegressionModel(override val uid: String, model: LightGBMBooster, 
 }
 
 object LightGBMRegressionModel extends ConstructorReadable[LightGBMRegressionModel]
+  with DefaultParamsReadable[LightGBMClassificationModel]


### PR DESCRIPTION
We had issues with `copy()` during our custom cross validation. https://github.com/Azure/mmlspark/commit/0deeca8304fae8734b5eb0a23ac68c3412f25446 didn't quite fix it for us. It seems like these additional changes are needed in order to fix it. 