### PR TITLE
Added getter for LightGBMBooster

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMClassifier.scala
+++ b/src/lightgbm/src/main/scala/LightGBMClassifier.scala
@@ -121,6 +121,8 @@ class LightGBMClassificationModel(
   def getFeatureImportances(importanceType: String): Array[Double] = {
     model.getFeatureImportances(importanceType)
   }
+
+  def getModel: LightGBMBooster = this.model
 }
 
 object LightGBMClassificationModel extends ConstructorReadable[LightGBMClassificationModel]

--- a/src/lightgbm/src/main/scala/LightGBMRegressor.scala
+++ b/src/lightgbm/src/main/scala/LightGBMRegressor.scala
@@ -117,6 +117,8 @@ class LightGBMRegressionModel(override val uid: String, model: LightGBMBooster, 
   def getFeatureImportances(importanceType: String): Array[Double] = {
     model.getFeatureImportances(importanceType)
   }
+
+  def getModel: LightGBMBooster = this.model
 }
 
 object LightGBMRegressionModel extends ConstructorReadable[LightGBMRegressionModel]


### PR DESCRIPTION
This is useful for getting internal information from the booster, such as the string representation. 