### PR TITLE
Cross reference jpmml-sparkml-lightgbm plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ attached to all clusters you create.
 
 Finally, ensure that your Spark cluster has at least Spark 2.1 and Scala 2.11.
 
-You can use MMLSpark in both your Scala and PySpark notebooks. To get started with our example notebooks import the following databricks archive: 
+You can use MMLSpark in both your Scala and PySpark notebooks. To get started with our example notebooks import the following databricks archive:
 
 ```https://mmlspark.blob.core.windows.net/dbcs/MMLSpark%20Examples%20v0.13.dbc```
 
@@ -272,6 +272,9 @@ Issue](https://help.github.com/articles/creating-an-issue/).
 
 * [Azure Machine Learning
   preview features](https://docs.microsoft.com/en-us/azure/machine-learning/preview)
+
+* [JPMML-SparkML plugin for converting MMLSpark LightGBM models to
+PMML](https://github.com/alipay/jpmml-sparkml-lightgbm)
 
 *Apache®, Apache Spark, and Spark® are either registered trademarks or
 trademarks of the Apache Software Foundation in the United States and/or other

--- a/docs/lightgbm.md
+++ b/docs/lightgbm.md
@@ -6,7 +6,7 @@
 distributed, high-performance gradient boosting (GBDT, GBRT, GBM, or
 MART) framework. This framework specializes in creating high-quality and
 GPU enabled decision tree algorithms for ranking, classification, and
-many other machine learning tasks. Light GBM is part of Microsoft's
+many other machine learning tasks. LightGBM is part of Microsoft's
 [DMTK](http://github.com/microsoft/dmtk) project.
 
 ### Advantages of LightGBM
@@ -69,3 +69,8 @@ The `LightGBMClassifier` and `LightGBMRegressor` use the SparkML API,
 inherit from the same base classes, integrate with SparkML pipelines,
 and can be tuned with [SparkML's cross
 validators](https://spark.apache.org/docs/latest/ml-tuning.html).
+
+Models built can be saved as SparkML pipeline with native LightGBM model
+using `saveNativeModel()`. Additionally, they are fully compatible with [PMML](https://en.wikipedia.org/wiki/Predictive_Model_Markup_Language) and
+can be converted to PMML format through the
+[JPMML-SparkML-LightGBM](https://github.com/alipay/jpmml-sparkml-lightgbm) plugin.


### PR DESCRIPTION
[JPMML-SparkML-LightGBM](https://github.com/alipay/jpmml-sparkml-lightgbm) plugin is now open-sourced. Here we cross reference each other. 