### PR TITLE
Update readme to fix the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,24 +84,23 @@ PySpark](http://mmlspark.azureedge.net/docs/pyspark/).
 
 ## Examples
 
-* Create a deep image classifier with transfer learning ([example 1])
+* Create a deep image classifier with transfer learning ([example 9])
 * Fit a LightGBM classification or regression model on a biochemical dataset
-  ([example 2]), to learn more check out the [LightGBM documentation
+  ([example 3]), to learn more check out the [LightGBM documentation
   page](docs/lightgbm.md).
 * Deploy a deep network as a distributed web service with [MMLSpark
   Serving](docs/mmlspark-serving.md)
 * Use web services in Spark with [HTTP on Apache Spark](docs/http.md)
-* Train a deep image classifier on Azure N-Series GPU VMs ([example 3])
 * Use Bi-directional LSTMs from Keras for medical entity extraction
-  ([example 4])
-* Create a text analytics system on Amazon book reviews ([example 5])
+  ([example 8])
+* Create a text analytics system on Amazon book reviews ([example 4])
 * Perform distributed hyperparameter tuning to identify Breast Cancer
-  ([example])
+  ([example 5])
 * Easily ingest images from HDFS into Spark `DataFrame` ([example 6])
 * Use OpenCV on Spark to manipulate images ([example 7])
 * Train classification and regression models easily via implicit featurization
-  of data ([example 8])
-* Train and evaluate a flight delay prediction system ([example 9])
+  of data ([example 1])
+* Train and evaluate a flight delay prediction system ([example 2])
 
 See our [notebooks](notebooks/samples/) for all examples.
 
@@ -125,6 +124,8 @@ See our [notebooks](notebooks/samples/) for all examples.
   "Deep Flower Classification"
 [example 10]: notebooks/gpu/DeepLearning%20-%20Distributed%20CNTK%20training.ipynb
   "CIFAR10 CNTK CNN Training"
+[example 11]: notebooks/samples/DeepLearning%20-%20Flower%20Image%20Classification.ipynb
+  "Deep Flower Classification"
 
 ## A short example
 


### PR DESCRIPTION
The examples are all messed up. This PR fixes it. 

Also, I could not find which notebook for 'Train a deep image classifier on Azure N-Series GPU VMs', in earlier commits it was [this file](https://github.com/Azure/mmlspark/blob/b81bc2b3dfb77d3ed47e30a4e1a2d208321b7045/notebooks/gpu/401%20-%20CNTK%20train%20on%20HDFS.ipynb), which seems to be removed now