### PR TITLE
fix off by one error on feature importances length

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMBooster.scala
+++ b/src/lightgbm/src/main/scala/LightGBMBooster.scala
@@ -141,6 +141,6 @@ class LightGBMBooster(val model: String) extends Serializable {
     LightGBMUtils.validate(
       lightgbmlib.LGBM_BoosterFeatureImportance(boosterPtr, -1, importanceTypeNum, featureImportances),
       "Booster FeatureImportance")
-    (0 to numFeatures).map(lightgbmlib.doubleArray_getitem(featureImportances, _)).toArray
+    (0 until numFeatures).map(lightgbmlib.doubleArray_getitem(featureImportances, _)).toArray
   }
 }

--- a/src/lightgbm/src/test/scala/VerifyLightGBMClassifier.scala
+++ b/src/lightgbm/src/test/scala/VerifyLightGBMClassifier.scala
@@ -9,9 +9,10 @@ import org.apache.spark.ml.evaluation.{BinaryClassificationEvaluator, Multiclass
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.DataFrame
 import java.nio.file.{Files, Path, Paths}
-import org.apache.commons.io.FileUtils
 
+import org.apache.commons.io.FileUtils
 import org.apache.spark.ml.tuning.{ParamGridBuilder, TrainValidationSplit}
+import org.apache.spark.ml.linalg.Vector
 
 /** Tests to validate the functionality of LightGBM module. */
 class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBMClassifier] {
@@ -114,6 +115,8 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
       val splitFeatureImportances = model.getFeatureImportances("split")
       val gainFeatureImportances = model.getFeatureImportances("gain")
       assert(splitFeatureImportances.length == gainFeatureImportances.length)
+      val featuresLength = trainData.select(featuresColumn).first().getAs[Vector](featuresColumn).size
+      assert(featuresLength == splitFeatureImportances.length)
       val eval = new BinaryClassificationEvaluator()
         .setLabelCol(labelColumnName)
         .setRawPredictionCol(rawPredCol)
@@ -146,6 +149,8 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
       val scoredResult = model.transform(trainData).drop(featuresColumn)
       val splitFeatureImportances = model.getFeatureImportances("split")
       val gainFeatureImportances = model.getFeatureImportances("gain")
+      val featuresLength = trainData.select(featuresColumn).first().getAs[Vector](featuresColumn).size
+      assert(featuresLength == splitFeatureImportances.length)
       assert(splitFeatureImportances.length == gainFeatureImportances.length)
       val eval = new MulticlassClassificationEvaluator()
         .setLabelCol(labelColumnName)

--- a/src/lightgbm/src/test/scala/VerifyLightGBMRegressor.scala
+++ b/src/lightgbm/src/test/scala/VerifyLightGBMRegressor.scala
@@ -6,6 +6,7 @@ package com.microsoft.ml.spark
 import org.apache.spark.ml.evaluation.RegressionEvaluator
 import org.apache.spark.ml.tuning.{CrossValidator, ParamGridBuilder, TrainValidationSplit}
 import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.sql.{Column, DataFrame}
 
 /** Tests to validate the functionality of LightGBM module.
@@ -141,7 +142,9 @@ class VerifyLightGBMRegressor extends Benchmarks with EstimatorFuzzing[LightGBMR
       val scoredResult = model.transform(trainData).drop(featuresColumn)
       val splitFeatureImportances = model.getFeatureImportances("split")
       val gainFeatureImportances = model.getFeatureImportances("gain")
+      val featuresLength = trainData.select(featuresColumn).first().getAs[Vector](featuresColumn).size
       assert(splitFeatureImportances.length == gainFeatureImportances.length)
+      assert(featuresLength == splitFeatureImportances.length)
       val eval = new RegressionEvaluator()
         .setLabelCol(labelCol)
         .setPredictionCol(predCol)


### PR DESCRIPTION
fix for off-by-one error noticed by a data scientist when getting feature importances from lightgbm + tests