### PR TITLE
Added categorical column support to LightGBM

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMParams.scala
+++ b/src/lightgbm/src/main/scala/LightGBMParams.scala
@@ -3,7 +3,7 @@
 
 package com.microsoft.ml.spark
 
-import org.apache.spark.ml.param.{DoubleParam, IntParam, Param}
+import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, StringArrayParam}
 import org.apache.spark.ml.util.DefaultParamsWritable
 
 /** Defines common parameters across all LightGBM learners.
@@ -118,4 +118,10 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
 
   def getVerbosity: Int = $(verbosity)
   def setVerbosity(value: Int): this.type = set(verbosity, value)
+
+  val categoricalColumns = new StringArrayParam(this, "categoricalColumns",
+    "List of categorical column names")
+
+  def getCategoricalColumns: Array[String] = $(categoricalColumns)
+  def setCategoricalColumns(value: Array[String]): this.type = set(categoricalColumns, value)
 }

--- a/src/lightgbm/src/main/scala/LightGBMUtils.scala
+++ b/src/lightgbm/src/main/scala/LightGBMUtils.scala
@@ -8,6 +8,7 @@ import java.net.{InetAddress, ServerSocket, Socket}
 import java.util.concurrent.Executors
 
 import com.microsoft.ml.lightgbm._
+import com.microsoft.ml.spark.schema.SparkSchema
 import org.apache.http.conn.util.InetAddressUtils
 import org.apache.spark.{BlockManagerUtils, SparkEnv, TaskContext}
 import org.apache.spark.ml.PipelineModel
@@ -54,6 +55,13 @@ object LightGBMUtils {
       lightgbmlib.LGBM_BoosterLoadModelFromString(lgbModelString, numItersOut, boosterOutPtr),
       "Booster LoadFromString")
     lightgbmlib.voidpp_value(boosterOutPtr)
+  }
+
+  def getCategoricalIndexes(df: DataFrame, categoricalColumns: Array[String]): Array[Int]  = {
+    val isCategorical = df.columns.map(columnName => (columnName, SparkSchema.isCategorical(df, columnName)))
+      .union(categoricalColumns.map(columnName => (columnName, true))).toMap
+    df.schema.fieldNames.zipWithIndex
+      .filter(name => isCategorical.contains(name._1) && isCategorical(name._1)).map(_._2)
   }
 
   /**

--- a/src/lightgbm/src/main/scala/TrainParams.scala
+++ b/src/lightgbm/src/main/scala/TrainParams.scala
@@ -22,6 +22,7 @@ abstract class TrainParams extends Serializable {
   def objective: String
   def modelString: String
   def verbosity: Int
+  def categoricalFeatures: Array[Int]
 
   override def toString(): String = {
     s"is_pre_partition=True boosting_type=gbdt tree_learner=$parallelism num_iterations=$numIterations " +
@@ -29,7 +30,8 @@ abstract class TrainParams extends Serializable {
       s"max_bin=$maxBin bagging_fraction=$baggingFraction bagging_freq=$baggingFreq " +
       s"bagging_seed=$baggingSeed early_stopping_round=$earlyStoppingRound " +
       s"feature_fraction=$featureFraction max_depth=$maxDepth min_sum_hessian_in_leaf=$minSumHessianInLeaf " +
-      s"num_machines=$numMachines objective=$objective verbosity=$verbosity"
+      s"num_machines=$numMachines objective=$objective verbosity=$verbosity " +
+      (if (categoricalFeatures.isEmpty) "" else s"categorical_feature=${categoricalFeatures.mkString(",")}")
   }
 }
 
@@ -40,7 +42,7 @@ case class ClassifierTrainParams(val parallelism: String, val numIterations: Int
                                  val baggingSeed: Int, val earlyStoppingRound: Int, val featureFraction: Double,
                                  val maxDepth: Int, val minSumHessianInLeaf: Double,
                                  val numMachines: Int, val objective: String, val modelString: String,
-                                 val isUnbalance: Boolean, val verbosity: Int)
+                                 val isUnbalance: Boolean, val verbosity: Int, val categoricalFeatures: Array[Int])
   extends TrainParams {
   override def toString(): String = {
     s"metric=binary_logloss,auc is_unbalance=${isUnbalance.toString} ${super.toString}"
@@ -55,7 +57,7 @@ case class RegressorTrainParams(val parallelism: String, val numIterations: Int,
                                 val baggingFraction: Double, val baggingFreq: Int,
                                 val baggingSeed: Int, val earlyStoppingRound: Int, val featureFraction: Double,
                                 val maxDepth: Int, val minSumHessianInLeaf: Double, val numMachines: Int,
-                                val modelString: String, val verbosity: Int)
+                                val modelString: String, val verbosity: Int, val categoricalFeatures: Array[Int])
   extends TrainParams {
   override def toString(): String = {
     s"alpha=$alpha tweedie_variance_power=$tweedieVariancePower ${super.toString}"

--- a/src/lightgbm/src/test/scala/VerifyLightGBMRegressor.scala
+++ b/src/lightgbm/src/test/scala/VerifyLightGBMRegressor.scala
@@ -4,6 +4,7 @@
 package com.microsoft.ml.spark
 
 import org.apache.spark.ml.evaluation.RegressionEvaluator
+import org.apache.spark.ml.feature.StringIndexer
 import org.apache.spark.ml.tuning.{CrossValidator, ParamGridBuilder, TrainValidationSplit}
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.ml.linalg.Vector
@@ -94,6 +95,48 @@ class VerifyLightGBMRegressor extends Benchmarks with EstimatorFuzzing[LightGBMR
     val avglabelWeight = lgbm.fit(datasetWithWeight)
       .transform(datasetWithWeight).select(avg("prediction")).first().getDouble(0)
     assert(avglabelWeight < avglabelNoWeight)
+  }
+
+  test("Verify LightGBM Regressor categorical parameter") {
+    // Increment port index
+    portIndex += numPartitions
+    val fileName = "flare.data1.train.csv"
+    val categoricalColumns = Array("Zurich class", "largest spot size", "spot distribution")
+    val newCategoricalColumns = categoricalColumns.map("c_" + _)
+    val labelColumnName = "M-class flares production by this region"
+    val fileLocation = DatasetUtils.regressionTrainFile(fileName).toString
+    val readDataset = readCSV(fileName, fileLocation).repartition(numPartitions)
+    val mca = new MultiColumnAdapter().setInputCols(categoricalColumns).setOutputCols(newCategoricalColumns)
+      .setBaseStage(new StringIndexer())
+    val mcaModel = mca.fit(readDataset)
+    val categoricalDataset = mcaModel.transform(readDataset).drop(categoricalColumns: _*)
+    val seed = 42
+    val data = categoricalDataset.randomSplit(Array(0.8, 0.2), seed.toLong)
+    val trainData = data(0)
+    val testData = data(1)
+
+    val featuresColumn = "_features"
+    val predCol = "prediction"
+    val lgbm = new LightGBMRegressor()
+      .setCategoricalColumns(newCategoricalColumns)
+      .setLabelCol(labelColumnName)
+      .setFeaturesCol(featuresColumn)
+      .setDefaultListenPort(LightGBMConstants.defaultLocalListenPort + portIndex)
+      .setNumLeaves(5)
+      .setNumIterations(10)
+      .setPredictionCol(predCol)
+
+    val featurizer = LightGBMUtils.featurizeData(trainData, labelColumnName, featuresColumn)
+    val transformedData = featurizer.transform(trainData)
+    val scoredData = featurizer.transform(testData)
+    val eval = new RegressionEvaluator()
+      .setLabelCol(labelColumnName)
+      .setPredictionCol(predCol)
+      .setMetricName("rmse")
+    val metric = eval.evaluate(
+      lgbm.fit(transformedData).transform(scoredData))
+    // Verify we get good result
+    assert(metric < 0.6)
   }
 
   test("Verify LightGBM Regressor with tweedie distribution") {


### PR DESCRIPTION
resolves issue #367 
This actually does two things:
1.) We natively and automatically pass to lightgbm any columns that have been string-indexed as categoricals
2.) We have a parameter to allow user to manually specify the categorical columns