### PR TITLE
fix categorical handling logic to use slot names and indexes

### DIFF
--- a/src/core/schema/src/main/scala/Categoricals.scala
+++ b/src/core/schema/src/main/scala/Categoricals.scala
@@ -170,7 +170,7 @@ object CategoricalUtilities {
 }
 
 /** A wrapper around level maps: Map[T -> Int] and Map[Int -> T] that converts
-  *   the data to/from Spark Metadata in both MLib and AzreML formats.
+  *   the data to/from Spark Metadata in both MLib and AzureML formats.
   * @param levels  The level values are assumed to be already sorted as needed
   * @param isOrdinal  A flag that indicates if the data are ordinal
   * @tparam T  Input levels could be String, Double, Int, Long, Boolean
@@ -184,7 +184,7 @@ class CategoricalMap[T](val levels: Array[T],
   /** Total number of levels */
   val numLevels = levels.length //TODO: add the maximum possible number of levels?
 
-  /** Spark DataType correspondint to type T */
+  /** Spark DataType corresponding to type T */
   val dataType = CategoricalUtilities.getCategoricalTypeForValue(levels.find(_ != null).head)
 
   /** Maps levels to the corresponding integer index */
@@ -206,7 +206,7 @@ class CategoricalMap[T](val levels: Array[T],
   def getLevelOption(index: Int): Option[T] =
     if (index < 0 || index >= numLevels) None else Some(levels(index))
 
-  /** Stores levels in Spark Metadata in either MLlib format */
+  /** Stores levels in Spark Metadata in MLlib format */
   private def toMetadataMllib(existingMetadata: Metadata): Metadata = {
     require(!isOrdinal, "Cannot save Ordinal data in MLlib Nominal format currently," +
                         " because it does not have a public constructor that accepts Ordinal")

--- a/src/lightgbm/src/main/scala/LightGBMClassifier.scala
+++ b/src/lightgbm/src/main/scala/LightGBMClassifier.scala
@@ -57,10 +57,11 @@ class LightGBMClassifier(override val uid: String)
      * translate the data to the LightGBM in-memory representation and train the models
      */
     val encoder = Encoders.kryo[LightGBMBooster]
-    val categoricals =
-      if (isDefined(categoricalColumns)) getCategoricalColumns
-      else Array.empty[String]
-    val categoricalIndexes = LightGBMUtils.getCategoricalIndexes(df, categoricals)
+
+    val categoricalSlotIndexesArr = get(categoricalSlotIndexes).getOrElse(Array.empty[Int])
+    val categoricalSlotNamesArr = get(categoricalSlotNames).getOrElse(Array.empty[String])
+    val categoricalIndexes = LightGBMUtils.getCategoricalIndexes(df, getFeaturesCol,
+      categoricalSlotIndexesArr, categoricalSlotNamesArr)
     /* The native code for getting numClasses is always 1 unless it is multiclass-classification problem
      * so we infer the actual numClasses from the dataset here
      */
@@ -75,7 +76,7 @@ class LightGBMClassifier(override val uid: String)
       getMaxBin, getBaggingFraction, getBaggingFreq, getBaggingSeed, getEarlyStoppingRound,
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numWorkers, getObjective, getModelString,
       getIsUnbalance, getVerbosity, categoricalIndexes, classes, metric)
-    log.info(s"LightGBMClassifier parameters: ${trainParams}")
+    log.info(s"LightGBMClassifier parameters: ${trainParams.toString}")
     val networkParams = NetworkParams(getDefaultListenPort, inetAddress, port)
 
     val lightGBMBooster = df

--- a/src/lightgbm/src/main/scala/LightGBMParams.scala
+++ b/src/lightgbm/src/main/scala/LightGBMParams.scala
@@ -3,7 +3,7 @@
 
 package com.microsoft.ml.spark
 
-import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, StringArrayParam}
+import org.apache.spark.ml.param._
 import org.apache.spark.ml.util.DefaultParamsWritable
 
 /** Defines common parameters across all LightGBM learners.
@@ -119,9 +119,15 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
   def getVerbosity: Int = $(verbosity)
   def setVerbosity(value: Int): this.type = set(verbosity, value)
 
-  val categoricalColumns = new StringArrayParam(this, "categoricalColumns",
-    "List of categorical column names")
+  val categoricalSlotIndexes = new IntArrayParam(this, "categoricalSlotIndexes",
+    "List of categorical column indexes, the slot index in the features column")
 
-  def getCategoricalColumns: Array[String] = $(categoricalColumns)
-  def setCategoricalColumns(value: Array[String]): this.type = set(categoricalColumns, value)
+  def getCategoricalSlotIndexes: Array[Int] = $(categoricalSlotIndexes)
+  def setCategoricalSlotIndexes(value: Array[Int]): this.type = set(categoricalSlotIndexes, value)
+
+  val categoricalSlotNames = new StringArrayParam(this, "categoricalSlotNames",
+    "List of categorical column slot names, the slot name in the features column")
+
+  def getCategoricalSlotNames: Array[String] = $(categoricalSlotNames)
+  def setCategoricalSlotNames(value: Array[String]): this.type = set(categoricalSlotNames, value)
 }

--- a/src/lightgbm/src/main/scala/LightGBMRegressor.scala
+++ b/src/lightgbm/src/main/scala/LightGBMRegressor.scala
@@ -74,15 +74,16 @@ class LightGBMRegressor(override val uid: String)
      * translate the data to the LightGBM in-memory representation and train the models
      */
     val encoder = Encoders.kryo[LightGBMBooster]
-    val categoricals =
-      if (isDefined(categoricalColumns)) getCategoricalColumns
-      else Array.empty[String]
-    val categoricalIndexes = LightGBMUtils.getCategoricalIndexes(df, categoricals)
+
+    val categoricalSlotIndexesArr = get(categoricalSlotIndexes).getOrElse(Array.empty[Int])
+    val categoricalSlotNamesArr = get(categoricalSlotNames).getOrElse(Array.empty[String])
+    val categoricalIndexes = LightGBMUtils.getCategoricalIndexes(df, getFeaturesCol,
+      categoricalSlotIndexesArr, categoricalSlotNamesArr)
     val trainParams = RegressorTrainParams(getParallelism, getNumIterations, getLearningRate, getNumLeaves,
       getObjective, getAlpha, getTweedieVariancePower, getMaxBin, getBaggingFraction, getBaggingFreq, getBaggingSeed,
       getEarlyStoppingRound, getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numWorkers, getModelString,
       getVerbosity, categoricalIndexes)
-    log.info(s"LightGBMRegressor parameters: ${trainParams}")
+    log.info(s"LightGBMRegressor parameters: ${trainParams.toString}")
     val networkParams = NetworkParams(getDefaultListenPort, inetAddress, port)
 
     val lightGBMBooster = df

--- a/src/lightgbm/src/test/scala/VerifyLightGBMClassifier.scala
+++ b/src/lightgbm/src/test/scala/VerifyLightGBMClassifier.scala
@@ -174,7 +174,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     val featuresColumn = "_features"
     val rawPredCol = "rawPrediction"
     val lgbm = new LightGBMClassifier()
-      .setCategoricalColumns(newCategoricalColumns)
+      .setCategoricalSlotNames(newCategoricalColumns)
       .setLabelCol(labelColumnName)
       .setFeaturesCol(featuresColumn)
       .setRawPredictionCol(rawPredCol)

--- a/src/lightgbm/src/test/scala/VerifyLightGBMRegressor.scala
+++ b/src/lightgbm/src/test/scala/VerifyLightGBMRegressor.scala
@@ -118,7 +118,7 @@ class VerifyLightGBMRegressor extends Benchmarks with EstimatorFuzzing[LightGBMR
     val featuresColumn = "_features"
     val predCol = "prediction"
     val lgbm = new LightGBMRegressor()
-      .setCategoricalColumns(newCategoricalColumns)
+      .setCategoricalSlotNames(newCategoricalColumns)
       .setLabelCol(labelColumnName)
       .setFeaturesCol(featuresColumn)
       .setDefaultListenPort(LightGBMConstants.defaultLocalListenPort + portIndex)


### PR DESCRIPTION
fixes issue https://github.com/Azure/mmlspark/issues/367
the previous fix was actually incorrect because it was for columns and not slots on the features column (very bad mistake!)
the user can now specify either the slot index within the vector features column or the slot name (but the slot name may not always be there, eg for sparse case it is removed in FastVectorAssembler to prevent OOM on very sparse data)