### PR TITLE
increase default timeout

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMParams.scala
+++ b/src/lightgbm/src/main/scala/LightGBMParams.scala
@@ -101,7 +101,7 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
   def setMinSumHessianInLeaf(value: Double): this.type = set(minSumHessianInLeaf, value)
 
   val timeout = new DoubleParam(this, "timeout", "Timeout in seconds")
-  setDefault(timeout -> 120)
+  setDefault(timeout -> 1200)
 
   def getTimeout: Double = $(timeout)
   def setTimeout(value: Double): this.type = set(timeout, value)


### PR DESCRIPTION
resolves issue mentioned here:
https://github.com/Azure/mmlspark/issues/379#issuecomment-454252196
for larger datasets we hit the timeout limit, it seems prudent to increase it