### PR TITLE
return list of param name to estimator and param from hyperparam builder

### DIFF
--- a/notebooks/samples/HyperParameterTuning - Fighting Breast Cancer.ipynb
+++ b/notebooks/samples/HyperParameterTuning - Fighting Breast Cancer.ipynb
@@ -98,12 +98,15 @@
     "from mmlspark import RandomSpace\n",
     "paramBuilder = \\\n",
     "  HyperparamBuilder() \\\n",
-    "    .addHyperparam(logReg, logReg.regParam, RangeHyperParam(0.1, 0.3, isDouble=True)) \\\n",
+    "    .addHyperparam(logReg, logReg.regParam, RangeHyperParam(0.1, 0.3)) \\\n",
     "    .addHyperparam(randForest, randForest.numTrees, DiscreteHyperParam([5,10])) \\\n",
     "    .addHyperparam(randForest, randForest.maxDepth, DiscreteHyperParam([3,5])) \\\n",
     "    .addHyperparam(gbt, gbt.maxBins, RangeHyperParam(8,16)) \\\n",
     "    .addHyperparam(gbt, gbt.maxDepth, DiscreteHyperParam([3,5]))\n",
-    "randomSpace = RandomSpace(paramBuilder.build())"
+    "searchSpace = paramBuilder.build()\n",
+    "# The search space is a list of params to tuples of estimator and hyperparam\n",
+    "print(searchSpace)\n",
+    "randomSpace = RandomSpace(searchSpace)"
    ]
   },
   {


### PR DESCRIPTION
resolves issue https://github.com/Azure/mmlspark/issues/473

HyperParam builder will now return a dictionary from param to (estimator, hyperparam), which is similar to parammap structure (parammap is dictionary from param to value but we can't quite do the same since we have a value generator and we need the estimator later on to extract the java param).
FYI @yueguoguo