### PR TITLE
Fix bug causing LightGBM to hang until timeout when there are empty partitions

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMConstants.scala
+++ b/src/lightgbm/src/main/scala/LightGBMConstants.scala
@@ -16,4 +16,7 @@ object LightGBMConstants {
   /** Binary classification objective
     */
   val binaryObjective: String = "binary"
+  /** Ignore worker status, used to ignore workers that get empty partitions
+    */
+  val ignoreStatus: String = "ignore"
 }


### PR DESCRIPTION
Fix bug causing LightGBM to hang until timeout when there are empty partitions

In the case that there are empty partitions we just ignore them and log a warning.  We prevent those workers from being included in NetworkInit.
Previously, we would just hang until timeout (network refused errors) because some workers would exit early while others would get stuck in UpdateOneIter waiting for them.
Also added additional debug to make it easier to keep track of when workers enter UpdateOneIter method (since that seems to be the case where they get stuck the most, when trying to sync with other workers).