### PR TITLE
add batch training support in lightgbm classifier and regressor

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMClassifier.scala
+++ b/src/lightgbm/src/main/scala/LightGBMClassifier.scala
@@ -58,6 +58,10 @@ class LightGBMClassifier(override val uid: String)
       if (isDefined(thresholds)) Some(getThresholds) else None, classifierTrainParams.numClass)
   }
 
+  def stringFromTrainedModel(model: LightGBMClassificationModel): String = {
+    model.getModel.model
+  }
+
   override def copy(extra: ParamMap): LightGBMClassifier = defaultCopy(extra)
 }
 

--- a/src/lightgbm/src/main/scala/LightGBMParams.scala
+++ b/src/lightgbm/src/main/scala/LightGBMParams.scala
@@ -159,4 +159,11 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
 
   def getLambdaL2: Double = $(lambdaL2)
   def setLambdaL2(value: Double): this.type = set(lambdaL2, value)
+
+  val numBatches = new IntParam(this, "numBatches",
+    "If greater than 0, splits data into separate batches during training")
+  setDefault(numBatches -> 0)
+
+  def getNumBatches: Int = $(numBatches)
+  def setNumBatches(value: Int): this.type = set(numBatches, value)
 }

--- a/src/lightgbm/src/main/scala/LightGBMRegressor.scala
+++ b/src/lightgbm/src/main/scala/LightGBMRegressor.scala
@@ -65,6 +65,10 @@ class LightGBMRegressor(override val uid: String)
     new LightGBMRegressionModel(uid, lightGBMBooster, getLabelCol, getFeaturesCol, getPredictionCol)
   }
 
+  def stringFromTrainedModel(model: LightGBMRegressionModel): String = {
+    model.getModel.model
+  }
+
   override def copy(extra: ParamMap): LightGBMRegressor = defaultCopy(extra)
 }
 


### PR DESCRIPTION
Resolves user request to add batch training to lightgbm on clusters with lower memory (note: not listed in issues)
User can now specify the number of batches (must be > 0) if they want to enable batch training.