### PR TITLE
[LightGBM] Implement `is_provide_training_metric` in Scala codes through JNI.

### DIFF
--- a/src/lightgbm/src/main/scala/LightGBMClassifier.scala
+++ b/src/lightgbm/src/main/scala/LightGBMClassifier.scala
@@ -48,7 +48,7 @@ class LightGBMClassifier(override val uid: String)
       getMaxBin, getBaggingFraction, getBaggingFreq, getBaggingSeed, getEarlyStoppingRound,
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numWorkers, getObjective, modelStr,
       getIsUnbalance, getVerbosity, categoricalIndexes, actualNumClasses, metric, getBoostFromAverage,
-      getBoostingType, getLambdaL1, getLambdaL2)
+      getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {

--- a/src/lightgbm/src/main/scala/LightGBMParams.scala
+++ b/src/lightgbm/src/main/scala/LightGBMParams.scala
@@ -167,4 +167,11 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
 
   def getNumBatches: Int = $(numBatches)
   def setNumBatches(value: Int): this.type = set(numBatches, value)
+
+  val isProvideTrainingMetric = new BooleanParam(this, "isProvideTrainingMetric",
+    "Whether output metric result over training dataset.")
+  setDefault(isProvideTrainingMetric -> false)
+
+  def getIsProvideTrainingMetric: Boolean = $(isProvideTrainingMetric)
+  def setisProvideTrainingMetric(value: Boolean): this.type = set(isProvideTrainingMetric, value)
 }

--- a/src/lightgbm/src/main/scala/LightGBMRanker.scala
+++ b/src/lightgbm/src/main/scala/LightGBMRanker.scala
@@ -45,7 +45,8 @@ class LightGBMRanker(override val uid: String)
     RankerTrainParams(getParallelism, getNumIterations, getLearningRate, getNumLeaves,
       getObjective, getMaxBin, getBaggingFraction, getBaggingFreq, getBaggingSeed, getEarlyStoppingRound,
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numWorkers, modelStr,
-      getVerbosity, categoricalIndexes, getBoostingType, getLambdaL1, getLambdaL2, getMaxPosition, getLabelGain)
+      getVerbosity, categoricalIndexes, getBoostingType, getLambdaL1, getLambdaL2, getMaxPosition, getLabelGain,
+      getIsProvideTrainingMetric)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRankerModel = {

--- a/src/lightgbm/src/main/scala/LightGBMRegressor.scala
+++ b/src/lightgbm/src/main/scala/LightGBMRegressor.scala
@@ -58,7 +58,8 @@ class LightGBMRegressor(override val uid: String)
     RegressorTrainParams(getParallelism, getNumIterations, getLearningRate, getNumLeaves,
       getObjective, getAlpha, getTweedieVariancePower, getMaxBin, getBaggingFraction, getBaggingFreq, getBaggingSeed,
       getEarlyStoppingRound, getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numWorkers, modelStr,
-      getVerbosity, categoricalIndexes, getBoostFromAverage, getBoostingType, getLambdaL1, getLambdaL2)
+      getVerbosity, categoricalIndexes, getBoostFromAverage, getBoostingType, getLambdaL1, getLambdaL2,
+      getIsProvideTrainingMetric)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRegressionModel = {

--- a/src/lightgbm/src/main/scala/TrainParams.scala
+++ b/src/lightgbm/src/main/scala/TrainParams.scala
@@ -26,8 +26,11 @@ abstract class TrainParams extends Serializable {
   def boostingType: String
   def lambdaL1: Double
   def lambdaL2: Double
+  def isProvideTrainingMetric: Boolean
 
   override def toString(): String = {
+    // Since passing `isProvideTrainingMetric` to LightGBM as a config parameter won't work,
+    // let's fetch and print training metrics in `TrainUtils.scala` through JNI.
     s"is_pre_partition=True boosting_type=$boostingType tree_learner=$parallelism num_iterations=$numIterations " +
       s"learning_rate=$learningRate num_leaves=$numLeaves " +
       s"max_bin=$maxBin bagging_fraction=$baggingFraction bagging_freq=$baggingFreq " +
@@ -48,7 +51,8 @@ case class ClassifierTrainParams(val parallelism: String, val numIterations: Int
                                  val numMachines: Int, val objective: String, val modelString: Option[String],
                                  val isUnbalance: Boolean, val verbosity: Int, val categoricalFeatures: Array[Int],
                                  val numClass: Int, val metric: String, val boostFromAverage: Boolean,
-                                 val boostingType: String, val lambdaL1: Double, val lambdaL2: Double)
+                                 val boostingType: String, val lambdaL1: Double, val lambdaL2: Double,
+                                 val isProvideTrainingMetric: Boolean)
   extends TrainParams {
   override def toString(): String = {
     val extraStr =
@@ -68,7 +72,8 @@ case class RegressorTrainParams(val parallelism: String, val numIterations: Int,
                                 val maxDepth: Int, val minSumHessianInLeaf: Double, val numMachines: Int,
                                 val modelString: Option[String], val verbosity: Int,
                                 val categoricalFeatures: Array[Int], val boostFromAverage: Boolean,
-                                val boostingType: String, val lambdaL1: Double, val lambdaL2: Double)
+                                val boostingType: String, val lambdaL1: Double, val lambdaL2: Double,
+                                val isProvideTrainingMetric: Boolean)
   extends TrainParams {
   override def toString(): String = {
     s"alpha=$alpha tweedie_variance_power=$tweedieVariancePower boost_from_average=${boostFromAverage.toString} " +

--- a/src/lightgbm/src/main/scala/TrainParams.scala
+++ b/src/lightgbm/src/main/scala/TrainParams.scala
@@ -89,9 +89,9 @@ case class RankerTrainParams(val parallelism: String, val numIterations: Int, va
                              val baggingSeed: Int, val earlyStoppingRound: Int, val featureFraction: Double,
                              val maxDepth: Int, val minSumHessianInLeaf: Double, val numMachines: Int,
                              val modelString: Option[String], val verbosity: Int,
-                             val categoricalFeatures: Array[Int],
-                             val boostingType: String, val lambdaL1: Double, val lambdaL2: Double,
-                             val maxPosition: Int, val labelGain: Array[Double])
+                             val categoricalFeatures: Array[Int], val boostingType: String,
+                             val lambdaL1: Double, val lambdaL2: Double, val maxPosition: Int,
+                             val labelGain: Array[Double], val isProvideTrainingMetric: Boolean)
   extends TrainParams {
   override def toString(): String = {
     val labelGainStr =

--- a/src/lightgbm/src/main/scala/TrainUtils.scala
+++ b/src/lightgbm/src/main/scala/TrainUtils.scala
@@ -166,6 +166,7 @@ private object TrainUtils extends Serializable {
         LightGBMUtils.validate(resultEval, "Booster Get Valid Eval")
         evalNames.zipWithIndex.foreach { case (evalName, index) =>
           val score = lightgbmlib.doubleArray_getitem(evalResults, index)
+          log.info(s"Valid $evalName=$score")
           val cmp =
             if (evalName.startsWith("auc") || evalName.startsWith("ndcg@") || evalName.startsWith("map@"))
               (x: Double, y: Double) => x > y


### PR DESCRIPTION
In LightGBM CLI binary, there is an useful config parameter named `is_provide_training_metric`. If it is turned on, all defined metrics for training data are printed after each iteration like:
```
[LightGBM] [Info] Iteration:1, training auc : 0.973625
[LightGBM] [Info] Iteration:1, training binary_logloss : 0.252878
[LightGBM] [Info] 5.466509 seconds elapsed, finished iteration 1
[LightGBM] [Info] Iteration:2, training auc : 0.98312
[LightGBM] [Info] Iteration:2, training binary_logloss : 0.185529
[LightGBM] [Info] 11.769265 seconds elapsed, finished iteration 2
```
These messages are extremely helpful when drawing metric curves during training.

However, it won't work if we pass `is_provide_training_metric` to LightGBM as a config parameter. Because this parameter is only consumed in the [CLI version](https://github.com/microsoft/LightGBM/blob/master/src/application/application.cpp#L118). Thus, we can extract metrics in Scala codes through JNI and print them after each iteration.

With this pull request merged, training metrics will be printed in each Spark executor's STDERR like:
```
19/05/16 11:21:53 INFO LightGBMClassifier: LightGBM running iteration: 66 with result: 0 and is finished: false
19/05/16 11:21:53 INFO LightGBMClassifier: Train auc=0.988505429160646
19/05/16 11:21:53 INFO LightGBMClassifier: Train binary_logloss=0.10812842975017523
19/05/16 11:21:54 INFO LightGBMClassifier: Valid auc=0.9887551394869192
19/05/16 11:21:54 INFO LightGBMClassifier: Valid binary_logloss=0.1077190874299224
19/05/16 11:21:54 INFO LightGBMClassifier: LightGBM worker calling LGBM_BoosterUpdateOneIter
19/05/16 11:21:56 INFO LightGBMClassifier: LightGBM running iteration: 67 with result: 0 and is finished: false
19/05/16 11:21:56 INFO LightGBMClassifier: Train auc=0.9885683489789646
19/05/16 11:21:56 INFO LightGBMClassifier: Train binary_logloss=0.10773347478545063
19/05/16 11:21:57 INFO LightGBMClassifier: Valid auc=0.9888314443159278
19/05/16 11:21:57 INFO LightGBMClassifier: Valid binary_logloss=0.10733361894798527
```