### PR TITLE
Add scala notebook examples

### DIFF
--- a/notebooks/samples/scala/Classification - AdultCensus.json
+++ b/notebooks/samples/scala/Classification - AdultCensus.json
@@ -1,0 +1,683 @@
+{
+  "paragraphs": [
+    {
+      "text": "%md\n## 101 - Training and Evaluating Classifiers with mmlspark\n\nIn this example, we try to predict incomes from the Adult Census dataset.\n\nFirst, we load in mmlspark. In Zeppelin, we load the dependency using the `%spark.dep` interpreter.\nPlease see `README.md` in the mmlspark repo for more information about how to load the mmlspark package into your spark context.\n",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:29:41.641",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true,
+          "completionKey": "TAB",
+          "completionSupport": false
+        },
+        "editorMode": "ace/mode/markdown",
+        "editorHide": true,
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003ch2\u003e101 - Training and Evaluating Classifiers with mmlspark\u003c/h2\u003e\n\u003cp\u003eIn this example, we try to predict incomes from the Adult Census dataset.\u003c/p\u003e\n\u003cp\u003eFirst, we load in mmlspark. In Zeppelin, we load the dependency using the \u003ccode\u003e%spark.dep\u003c/code\u003e interpreter.\u003cbr/\u003ePlease see \u003ccode\u003eREADME.md\u003c/code\u003e in the mmlspark repo for more information about how to load the mmlspark package into your spark context.\u003c/p\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1558740442156_-18249743",
+      "id": "20190524-162722_517215741",
+      "dateCreated": "2019-05-24 16:27:22.156",
+      "dateStarted": "2019-05-24 16:29:41.641",
+      "dateFinished": "2019-05-24 16:29:41.647",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%spark.dep\nz.load(\"Azure:mmlspark:0.17\")",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 15:33:54.717",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "scala",
+          "editOnDblClick": false,
+          "completionKey": "TAB",
+          "completionSupport": true
+        },
+        "editorMode": "ace/mode/scala"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TEXT",
+            "data": "res0: org.apache.zeppelin.dep.Dependency \u003d org.apache.zeppelin.dep.Dependency@ad2ed0f\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1558657539798_1492374222",
+      "id": "20190523-172539_613186693",
+      "dateCreated": "2019-05-23 17:25:39.798",
+      "dateStarted": "2019-05-24 15:33:54.730",
+      "dateFinished": "2019-05-24 15:34:23.305",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\nThen we load in the packages we need.",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:29:57.203",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true,
+          "completionKey": "TAB",
+          "completionSupport": false
+        },
+        "editorMode": "ace/mode/markdown",
+        "editorHide": true,
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003cp\u003eThen we load in the packages we need.\u003c/p\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1558740586130_100953689",
+      "id": "20190524-162946_1779279677",
+      "dateCreated": "2019-05-24 16:29:46.130",
+      "dateStarted": "2019-05-24 16:29:57.203",
+      "dateFinished": "2019-05-24 16:29:57.207",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "import com.microsoft.ml.spark.{TrainClassifier,ComputeModelStatistics, TrainedClassifierModel}\nimport scala.io.Source\nimport org.apache.spark.sql.{Dataset, SparkSession}\nimport spark.implicits._\nimport org.apache.spark.sql.types._\nimport org.apache.spark.ml.classification.LogisticRegression",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:21:04.561",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "scala",
+          "editOnDblClick": false,
+          "completionKey": "TAB",
+          "completionSupport": true
+        },
+        "editorMode": "ace/mode/scala"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TEXT",
+            "data": "import com.microsoft.ml.spark.{TrainClassifier, ComputeModelStatistics, TrainedClassifierModel}\nimport scala.io.Source\nimport org.apache.spark.sql.{Dataset, SparkSession}\nimport spark.implicits._\nimport org.apache.spark.sql.types._\nimport org.apache.spark.ml.classification.LogisticRegression\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1558657503149_882244572",
+      "id": "20190523-172503_672281001",
+      "dateCreated": "2019-05-23 17:25:03.149",
+      "dateStarted": "2019-05-24 16:21:04.572",
+      "dateFinished": "2019-05-24 16:21:05.684",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md \n\nNow let\u0027s read the data and split it to train and test sets:\n",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:08:53.835",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true,
+          "completionKey": "TAB",
+          "completionSupport": false
+        },
+        "editorMode": "ace/mode/markdown",
+        "editorHide": true,
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003cp\u003eNow let\u0026rsquo;s read the data and split it to train and test sets:\u003c/p\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1558739330754_-1373053460",
+      "id": "20190524-160850_171105258",
+      "dateCreated": "2019-05-24 16:08:50.754",
+      "dateStarted": "2019-05-24 16:08:53.836",
+      "dateFinished": "2019-05-24 16:09:06.740",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "val dataFilePath \u003d \"AdultCensusIncome.csv\"\nval strData \u003d scala.io.Source.fromURL(\"https://mmlspark.azureedge.net/datasets/\" + dataFilePath).mkString\nval listData \u003d strData.split(\"\\n\").filter(_ !\u003d \"\")\nval csvDS \u003d sc.parallelize(listData).toDS\n\nval schema \u003d StructType(Seq(\n  StructField(\"age\", IntegerType, true),\n  StructField(\"workclass\", StringType, true),\n  StructField(\"fnlwgt\", DoubleType, true),\n  StructField(\"education\", StringType, true),\n  StructField(\"education-num\", DoubleType, true),\n  StructField(\"marital-status\", StringType, true),\n  StructField(\"occupation\", StringType, true),\n  StructField(\"relationship\", StringType, true),\n  StructField(\"race\", StringType, true),\n  StructField(\"sex\", StringType, true),\n  StructField(\"capital-gain\", DoubleType, true),\n  StructField(\"capital-loss\", DoubleType, true),\n  StructField(\"hours-per-week\", DoubleType, true),\n  StructField(\"native-country\", StringType, true),\n  StructField(\"income\", StringType, true)))\n  \nval df \u003d spark.read.option(\"header\", true).option(\"inferSchema\",false).option(\"treatEmptyValuesAsNulls\", \"false\").schema(schema).csv(csvDS)\nval data \u003d df.select($\"education\", $\"marital-status\", $\"hours-per-week\", $\"income\")\nval Array(train, test) \u003d data.randomSplit(Array(0.75, 0.25), seed\u003d123)\n\nz.show(data.limit(10))",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:12:37.703",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {
+          "0": {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false,
+              "setting": {
+                "table": {
+                  "tableGridState": {},
+                  "tableColumnTypeState": {
+                    "names": {
+                      "education": "string",
+                      "marital-status": "string",
+                      "hours-per-week": "string",
+                      "income": "string"
+                    },
+                    "updated": false
+                  },
+                  "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                  "tableOptionValue": {
+                    "useFilter": false,
+                    "showPagination": false,
+                    "showAggregationFooter": false
+                  },
+                  "updated": false,
+                  "initialized": false
+                }
+              },
+              "commonSetting": {}
+            }
+          }
+        },
+        "editorSetting": {
+          "language": "scala",
+          "editOnDblClick": false,
+          "completionKey": "TAB",
+          "completionSupport": true
+        },
+        "editorMode": "ace/mode/scala"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "education\tmarital-status\thours-per-week\tincome\n Bachelors\t Never-married\t40.0\t \u003c\u003d50K\r\n Bachelors\t Married-civ-spouse\t13.0\t \u003c\u003d50K\r\n HS-grad\t Divorced\t40.0\t \u003c\u003d50K\r\n 11th\t Married-civ-spouse\t40.0\t \u003c\u003d50K\r\n Bachelors\t Married-civ-spouse\t40.0\t \u003c\u003d50K\r\n Masters\t Married-civ-spouse\t40.0\t \u003c\u003d50K\r\n 9th\t Married-spouse-absent\t16.0\t \u003c\u003d50K\r\n HS-grad\t Married-civ-spouse\t45.0\t \u003e50K\r\n Masters\t Never-married\t50.0\t \u003e50K\r\n Bachelors\t Married-civ-spouse\t40.0\t \u003e50K\r\n"
+          },
+          {
+            "type": "TEXT",
+            "data": "dataFilePath: String \u003d AdultCensusIncome.csv\nstrData: String \u003d\nage, workclass, fnlwgt, education, education-num, marital-status, occupation, relationship, race, sex, capital-gain, capital-loss, hours-per-week, native-country, income\n39, State-gov, 77516, Bachelors, 13, Never-married, Adm-clerical, Not-in-family, White, Male, 2174, 0, 40, United-States, \u003c\u003d50K\n50, Self-emp-not-inc, 83311, Bachelors, 13, Married-civ-spouse, Exec-managerial, Husband, White, Male, 0, 0, 13, United-States, \u003c\u003d50K\n38, Private, 215646, HS-grad, 9, Divorced, Handlers-cleaners, Not-in-family, White, Male, 0, 0, 40, United-States, \u003c\u003d50K\n53, Private, 234721, 11th, 7, Married-civ-spouse, Handlers-cleaners, Husband, Black, Male, 0, 0, 40, United-States, \u003c\u003d50K\n28, Private, 338409, Bachelors, 13, Married-civ-spouse, Pro..."
+          }
+        ]
+      },
+      "runtimeInfos": {
+        "jobUrl": {
+          "propertyName": "jobUrl",
+          "label": "SPARK JOB",
+          "tooltip": "View in Spark web UI",
+          "group": "spark",
+          "values": [
+            "http://192.168.86.152:4040/jobs/job?id\u003d50",
+            "http://192.168.86.152:4040/jobs/job?id\u003d51"
+          ],
+          "interpreterSettingId": "spark"
+        }
+      },
+      "apps": [],
+      "jobName": "paragraph_1558657530356_-1525022437",
+      "id": "20190523-172530_1022344373",
+      "dateCreated": "2019-05-23 17:25:30.357",
+      "dateStarted": "2019-05-24 16:12:37.766",
+      "dateFinished": "2019-05-24 16:12:39.588",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\nTrainClassifier can be used to initialize and fit a model. It wraps SparkML classifiers.\n\nNote that it implicitly converts the data into the format expected by the algorithm: tokenize and hash strings, one-hot encodes categorical variables, assembles the features into a vector and so on. The parameter `numFeatures` controls the number of hashed features.\n",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:30:42.411",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true,
+          "completionKey": "TAB",
+          "completionSupport": false
+        },
+        "editorMode": "ace/mode/markdown",
+        "editorHide": true,
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003cp\u003eTrainClassifier can be used to initialize and fit a model. It wraps SparkML classifiers.\u003c/p\u003e\n\u003cp\u003eNote that it implicitly converts the data into the format expected by the algorithm: tokenize and hash strings, one-hot encodes categorical variables, assembles the features into a vector and so on. The parameter \u003ccode\u003enumFeatures\u003c/code\u003e controls the number of hashed features.\u003c/p\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1558737545857_671296839",
+      "id": "20190524-153905_1764382828",
+      "dateCreated": "2019-05-24 15:39:05.857",
+      "dateStarted": "2019-05-24 16:30:42.412",
+      "dateFinished": "2019-05-24 16:30:42.423",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "val lr \u003d new LogisticRegression\nval model \u003d new TrainClassifier().setModel(lr).setLabelCol(\"income\").setNumFeatures(256).fit(train)\n// You can save and load the model as needed\n// model.write.overwrite().save(\"adultclassification.mml\")\n// val loadedModel \u003d TrainedClassifierModel.load(\"adultCensusIncomeModel.mml\")",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:30:54.358",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "scala",
+          "editOnDblClick": false,
+          "completionKey": "TAB",
+          "completionSupport": true
+        },
+        "editorMode": "ace/mode/scala"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TEXT",
+            "data": "lr: org.apache.spark.ml.classification.LogisticRegression \u003d logreg_8673da619007\nmodel: com.microsoft.ml.spark.TrainedClassifierModel \u003d TrainClassifier_a51e04e7456d\n"
+          }
+        ]
+      },
+      "runtimeInfos": {
+        "jobUrl": {
+          "propertyName": "jobUrl",
+          "label": "SPARK JOB",
+          "tooltip": "View in Spark web UI",
+          "group": "spark",
+          "values": [
+            "http://192.168.86.152:4040/jobs/job?id\u003d844",
+            "http://192.168.86.152:4040/jobs/job?id\u003d845",
+            "http://192.168.86.152:4040/jobs/job?id\u003d846",
+            "http://192.168.86.152:4040/jobs/job?id\u003d847",
+            "http://192.168.86.152:4040/jobs/job?id\u003d848",
+            "http://192.168.86.152:4040/jobs/job?id\u003d849",
+            "http://192.168.86.152:4040/jobs/job?id\u003d850",
+            "http://192.168.86.152:4040/jobs/job?id\u003d851",
+            "http://192.168.86.152:4040/jobs/job?id\u003d852",
+            "http://192.168.86.152:4040/jobs/job?id\u003d853",
+            "http://192.168.86.152:4040/jobs/job?id\u003d854",
+            "http://192.168.86.152:4040/jobs/job?id\u003d855",
+            "http://192.168.86.152:4040/jobs/job?id\u003d856",
+            "http://192.168.86.152:4040/jobs/job?id\u003d857",
+            "http://192.168.86.152:4040/jobs/job?id\u003d858",
+            "http://192.168.86.152:4040/jobs/job?id\u003d859",
+            "http://192.168.86.152:4040/jobs/job?id\u003d860",
+            "http://192.168.86.152:4040/jobs/job?id\u003d861",
+            "http://192.168.86.152:4040/jobs/job?id\u003d862",
+            "http://192.168.86.152:4040/jobs/job?id\u003d863",
+            "http://192.168.86.152:4040/jobs/job?id\u003d864",
+            "http://192.168.86.152:4040/jobs/job?id\u003d865",
+            "http://192.168.86.152:4040/jobs/job?id\u003d866",
+            "http://192.168.86.152:4040/jobs/job?id\u003d867",
+            "http://192.168.86.152:4040/jobs/job?id\u003d868",
+            "http://192.168.86.152:4040/jobs/job?id\u003d869",
+            "http://192.168.86.152:4040/jobs/job?id\u003d870",
+            "http://192.168.86.152:4040/jobs/job?id\u003d871",
+            "http://192.168.86.152:4040/jobs/job?id\u003d872",
+            "http://192.168.86.152:4040/jobs/job?id\u003d873",
+            "http://192.168.86.152:4040/jobs/job?id\u003d874",
+            "http://192.168.86.152:4040/jobs/job?id\u003d875",
+            "http://192.168.86.152:4040/jobs/job?id\u003d876",
+            "http://192.168.86.152:4040/jobs/job?id\u003d877",
+            "http://192.168.86.152:4040/jobs/job?id\u003d878",
+            "http://192.168.86.152:4040/jobs/job?id\u003d879",
+            "http://192.168.86.152:4040/jobs/job?id\u003d880",
+            "http://192.168.86.152:4040/jobs/job?id\u003d881",
+            "http://192.168.86.152:4040/jobs/job?id\u003d882",
+            "http://192.168.86.152:4040/jobs/job?id\u003d883",
+            "http://192.168.86.152:4040/jobs/job?id\u003d884",
+            "http://192.168.86.152:4040/jobs/job?id\u003d885",
+            "http://192.168.86.152:4040/jobs/job?id\u003d886",
+            "http://192.168.86.152:4040/jobs/job?id\u003d887",
+            "http://192.168.86.152:4040/jobs/job?id\u003d888",
+            "http://192.168.86.152:4040/jobs/job?id\u003d889",
+            "http://192.168.86.152:4040/jobs/job?id\u003d890",
+            "http://192.168.86.152:4040/jobs/job?id\u003d891",
+            "http://192.168.86.152:4040/jobs/job?id\u003d892",
+            "http://192.168.86.152:4040/jobs/job?id\u003d893",
+            "http://192.168.86.152:4040/jobs/job?id\u003d894",
+            "http://192.168.86.152:4040/jobs/job?id\u003d895",
+            "http://192.168.86.152:4040/jobs/job?id\u003d896",
+            "http://192.168.86.152:4040/jobs/job?id\u003d897",
+            "http://192.168.86.152:4040/jobs/job?id\u003d898",
+            "http://192.168.86.152:4040/jobs/job?id\u003d899",
+            "http://192.168.86.152:4040/jobs/job?id\u003d900",
+            "http://192.168.86.152:4040/jobs/job?id\u003d901",
+            "http://192.168.86.152:4040/jobs/job?id\u003d902",
+            "http://192.168.86.152:4040/jobs/job?id\u003d903",
+            "http://192.168.86.152:4040/jobs/job?id\u003d904",
+            "http://192.168.86.152:4040/jobs/job?id\u003d905",
+            "http://192.168.86.152:4040/jobs/job?id\u003d906",
+            "http://192.168.86.152:4040/jobs/job?id\u003d907",
+            "http://192.168.86.152:4040/jobs/job?id\u003d908",
+            "http://192.168.86.152:4040/jobs/job?id\u003d909",
+            "http://192.168.86.152:4040/jobs/job?id\u003d910",
+            "http://192.168.86.152:4040/jobs/job?id\u003d911",
+            "http://192.168.86.152:4040/jobs/job?id\u003d912",
+            "http://192.168.86.152:4040/jobs/job?id\u003d913",
+            "http://192.168.86.152:4040/jobs/job?id\u003d914",
+            "http://192.168.86.152:4040/jobs/job?id\u003d915",
+            "http://192.168.86.152:4040/jobs/job?id\u003d916",
+            "http://192.168.86.152:4040/jobs/job?id\u003d917",
+            "http://192.168.86.152:4040/jobs/job?id\u003d918",
+            "http://192.168.86.152:4040/jobs/job?id\u003d919",
+            "http://192.168.86.152:4040/jobs/job?id\u003d920",
+            "http://192.168.86.152:4040/jobs/job?id\u003d921",
+            "http://192.168.86.152:4040/jobs/job?id\u003d922",
+            "http://192.168.86.152:4040/jobs/job?id\u003d923",
+            "http://192.168.86.152:4040/jobs/job?id\u003d924",
+            "http://192.168.86.152:4040/jobs/job?id\u003d925",
+            "http://192.168.86.152:4040/jobs/job?id\u003d926",
+            "http://192.168.86.152:4040/jobs/job?id\u003d927",
+            "http://192.168.86.152:4040/jobs/job?id\u003d928",
+            "http://192.168.86.152:4040/jobs/job?id\u003d929",
+            "http://192.168.86.152:4040/jobs/job?id\u003d930",
+            "http://192.168.86.152:4040/jobs/job?id\u003d931",
+            "http://192.168.86.152:4040/jobs/job?id\u003d932",
+            "http://192.168.86.152:4040/jobs/job?id\u003d933",
+            "http://192.168.86.152:4040/jobs/job?id\u003d934",
+            "http://192.168.86.152:4040/jobs/job?id\u003d935",
+            "http://192.168.86.152:4040/jobs/job?id\u003d936",
+            "http://192.168.86.152:4040/jobs/job?id\u003d937",
+            "http://192.168.86.152:4040/jobs/job?id\u003d938",
+            "http://192.168.86.152:4040/jobs/job?id\u003d939",
+            "http://192.168.86.152:4040/jobs/job?id\u003d940",
+            "http://192.168.86.152:4040/jobs/job?id\u003d941",
+            "http://192.168.86.152:4040/jobs/job?id\u003d942",
+            "http://192.168.86.152:4040/jobs/job?id\u003d943",
+            "http://192.168.86.152:4040/jobs/job?id\u003d944",
+            "http://192.168.86.152:4040/jobs/job?id\u003d945",
+            "http://192.168.86.152:4040/jobs/job?id\u003d946",
+            "http://192.168.86.152:4040/jobs/job?id\u003d947",
+            "http://192.168.86.152:4040/jobs/job?id\u003d948",
+            "http://192.168.86.152:4040/jobs/job?id\u003d949",
+            "http://192.168.86.152:4040/jobs/job?id\u003d950",
+            "http://192.168.86.152:4040/jobs/job?id\u003d951",
+            "http://192.168.86.152:4040/jobs/job?id\u003d952",
+            "http://192.168.86.152:4040/jobs/job?id\u003d953",
+            "http://192.168.86.152:4040/jobs/job?id\u003d954",
+            "http://192.168.86.152:4040/jobs/job?id\u003d955",
+            "http://192.168.86.152:4040/jobs/job?id\u003d956",
+            "http://192.168.86.152:4040/jobs/job?id\u003d957",
+            "http://192.168.86.152:4040/jobs/job?id\u003d958",
+            "http://192.168.86.152:4040/jobs/job?id\u003d959",
+            "http://192.168.86.152:4040/jobs/job?id\u003d960",
+            "http://192.168.86.152:4040/jobs/job?id\u003d961",
+            "http://192.168.86.152:4040/jobs/job?id\u003d962",
+            "http://192.168.86.152:4040/jobs/job?id\u003d963",
+            "http://192.168.86.152:4040/jobs/job?id\u003d964",
+            "http://192.168.86.152:4040/jobs/job?id\u003d965",
+            "http://192.168.86.152:4040/jobs/job?id\u003d966",
+            "http://192.168.86.152:4040/jobs/job?id\u003d967",
+            "http://192.168.86.152:4040/jobs/job?id\u003d968",
+            "http://192.168.86.152:4040/jobs/job?id\u003d969",
+            "http://192.168.86.152:4040/jobs/job?id\u003d970",
+            "http://192.168.86.152:4040/jobs/job?id\u003d971",
+            "http://192.168.86.152:4040/jobs/job?id\u003d972",
+            "http://192.168.86.152:4040/jobs/job?id\u003d973",
+            "http://192.168.86.152:4040/jobs/job?id\u003d974",
+            "http://192.168.86.152:4040/jobs/job?id\u003d975",
+            "http://192.168.86.152:4040/jobs/job?id\u003d976",
+            "http://192.168.86.152:4040/jobs/job?id\u003d977",
+            "http://192.168.86.152:4040/jobs/job?id\u003d978",
+            "http://192.168.86.152:4040/jobs/job?id\u003d979",
+            "http://192.168.86.152:4040/jobs/job?id\u003d980",
+            "http://192.168.86.152:4040/jobs/job?id\u003d981",
+            "http://192.168.86.152:4040/jobs/job?id\u003d982",
+            "http://192.168.86.152:4040/jobs/job?id\u003d983",
+            "http://192.168.86.152:4040/jobs/job?id\u003d984",
+            "http://192.168.86.152:4040/jobs/job?id\u003d985",
+            "http://192.168.86.152:4040/jobs/job?id\u003d986"
+          ],
+          "interpreterSettingId": "spark"
+        }
+      },
+      "apps": [],
+      "jobName": "paragraph_1558736291017_-1515471822",
+      "id": "20190524-151811_1456028740",
+      "dateCreated": "2019-05-24 15:18:11.018",
+      "dateStarted": "2019-05-24 16:30:54.369",
+      "dateFinished": "2019-05-24 16:31:10.158",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\nAfter the model is trained, we score it against the test dataset and view metrics.",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:23:29.509",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true,
+          "completionKey": "TAB",
+          "completionSupport": false
+        },
+        "editorMode": "ace/mode/markdown",
+        "editorHide": true,
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003cp\u003eAfter the model is trained, we score it against the test dataset and view metrics.\u003c/p\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1558739685319_-466914917",
+      "id": "20190524-161445_830317066",
+      "dateCreated": "2019-05-24 16:14:45.319",
+      "dateStarted": "2019-05-24 16:20:33.177",
+      "dateFinished": "2019-05-24 16:20:33.187",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "val prediction \u003d model.transform(test)\nval metrics \u003d new ComputeModelStatistics().transform(prediction)\nz.show(metrics.drop(\"confusion_matrix\").limit(1))",
+      "user": "admin",
+      "dateUpdated": "2019-05-24 16:32:26.948",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {
+          "0": {
+            "graph": {
+              "mode": "table",
+              "height": 84.5,
+              "optionOpen": false,
+              "setting": {
+                "table": {
+                  "tableGridState": {},
+                  "tableColumnTypeState": {
+                    "names": {
+                      "evaluation_type": "string",
+                      "accuracy": "string",
+                      "precision": "string",
+                      "recall": "string",
+                      "AUC": "string"
+                    },
+                    "updated": false
+                  },
+                  "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                  "tableOptionValue": {
+                    "useFilter": false,
+                    "showPagination": false,
+                    "showAggregationFooter": false
+                  },
+                  "updated": false,
+                  "initialized": false
+                }
+              },
+              "commonSetting": {}
+            }
+          },
+          "1": {
+            "graph": {
+              "mode": "table",
+              "height": 90.8,
+              "optionOpen": false
+            }
+          }
+        },
+        "editorSetting": {
+          "language": "scala",
+          "editOnDblClick": false,
+          "completionKey": "TAB",
+          "completionSupport": true
+        },
+        "editorMode": "ace/mode/scala"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "evaluation_type\taccuracy\tprecision\trecall\tAUC\nClassification\t0.8231527093596059\t0.6671698113207547\t0.4704630122405535\t0.5470916331331912\n"
+          },
+          {
+            "type": "TEXT",
+            "data": "prediction: org.apache.spark.sql.DataFrame \u003d [education: string, marital-status: string ... 4 more fields]\nmetrics: org.apache.spark.sql.DataFrame \u003d [evaluation_type: string, confusion_matrix: matrix ... 4 more fields]\n"
+          }
+        ]
+      },
+      "runtimeInfos": {
+        "jobUrl": {
+          "propertyName": "jobUrl",
+          "label": "SPARK JOB",
+          "tooltip": "View in Spark web UI",
+          "group": "spark",
+          "values": [
+            "http://192.168.86.152:4040/jobs/job?id\u003d997",
+            "http://192.168.86.152:4040/jobs/job?id\u003d998",
+            "http://192.168.86.152:4040/jobs/job?id\u003d999",
+            "http://192.168.86.152:4040/jobs/job?id\u003d1000",
+            "http://192.168.86.152:4040/jobs/job?id\u003d1001",
+            "http://192.168.86.152:4040/jobs/job?id\u003d1002",
+            "http://192.168.86.152:4040/jobs/job?id\u003d1003",
+            "http://192.168.86.152:4040/jobs/job?id\u003d1004",
+            "http://192.168.86.152:4040/jobs/job?id\u003d1005",
+            "http://192.168.86.152:4040/jobs/job?id\u003d1006"
+          ],
+          "interpreterSettingId": "spark"
+        }
+      },
+      "apps": [],
+      "jobName": "paragraph_1558739939962_1578028212",
+      "id": "20190524-161859_1100073829",
+      "dateCreated": "2019-05-24 16:18:59.962",
+      "dateStarted": "2019-05-24 16:32:14.552",
+      "dateFinished": "2019-05-24 16:32:15.947",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    }
+  ],
+  "name": "Classification - Adult Census",
+  "id": "2ECAJQRJ8",
+  "noteParams": {},
+  "noteForms": {},
+  "angularObjects": {
+    "md:shared_process": [],
+    "sh:shared_process": [],
+    "spark:shared_process": []
+  },
+  "config": {
+    "isZeppelinNotebookCronEnable": false
+  },
+  "info": {}
+}

--- a/notebooks/samples/scala/README.md
+++ b/notebooks/samples/scala/README.md
@@ -1,0 +1,8 @@
+## Demo Notebooks for mmlspark In Apache Zeppelin
+
+In order to view the demo notebooks:
+1. Obtain the url for the notebook you want from the github repository. You want the url to the base file (ends in `json`). It should look something like this:
+https://github.com/mmlspark/blob/master/notebooks/samples/scala/Classification - AdultCensus.json
+2. Go to https://www.zepl.com/explore and paste the link to the input bar. This will take you to a link that displays the notebook.
+
+

--- a/notebooks/samples/scala/Regression with L-BFGS.json
+++ b/notebooks/samples/scala/Regression with L-BFGS.json
@@ -1,0 +1,873 @@
+﻿{
+    "paragraphs": [{
+        "text": "%md\n## 102 - Training Regression Algorithms with the L-BFGS Solver¶ \nIn this example, we run a linear regression on the Flight Delay dataset to predict the delay times.\n\nWe demonstrate how to use the `TrainRegressor` and the `ComputePerInstanceStatistics` APIs.\n\nFirst, we load in mmlspark. In Zeppelin, we load the dependency using the `%spark.dep` interpreter.\nPlease see `README.md` in the mmlspark repo for more information about how to load the mmlspark package into your spark context.\n",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:10:00-0700",
+        "config": {
+            "tableHide": false,
+            "editorSetting": {
+                "language": "markdown",
+                "editOnDblClick": true,
+                "completionKey": "TAB",
+                "completionSupport": false
+            },
+            "colWidth": 12,
+            "editorMode": "ace/mode/markdown",
+            "fontSize": 9,
+            "editorHide": true,
+            "results": {},
+            "enabled": true
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "HTML",
+                "data": "<div class=\"markdown-body\">\n<h2>102 - Training Regression Algorithms with the L-BFGS Solver¶</h2>\n<p>In this example, we run a linear regression on the Flight Delay dataset to predict the delay times.</p>\n<p>We demonstrate how to use the <code>TrainRegressor</code> and the <code>ComputePerInstanceStatistics</code> APIs.</p>\n<p>First, we load in mmlspark. In Zeppelin, we load the dependency using the <code>%spark.dep</code> interpreter.<br/>Please see <code>README.md</code> in the mmlspark repo for more information about how to load the mmlspark package into your spark context.</p>\n</div>"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559099163549_178429232",
+        "id": "20190524-162722_517215741",
+        "dateCreated": "2019-05-28T20:06:03-0700",
+        "dateStarted": "2019-05-29T22:10:00-0700",
+        "dateFinished": "2019-05-29T22:10:00-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "focus": true,
+        "$$hashKey": "object:52479"
+    }, {
+        "text": "%spark.dep\nz.load(\"Azure:mmlspark:0.17\")",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:04:09-0700",
+        "config": {
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "colWidth": 12,
+            "editorMode": "ace/mode/scala",
+            "fontSize": 9,
+            "results": {},
+            "enabled": true
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TEXT",
+                "data": "res0: org.apache.zeppelin.dep.Dependency = org.apache.zeppelin.dep.Dependency@7f911e5b\n"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559099163554_1420692846",
+        "id": "20190523-172539_613186693",
+        "dateCreated": "2019-05-28T20:06:03-0700",
+        "dateStarted": "2019-05-29T22:04:09-0700",
+        "dateFinished": "2019-05-29T22:05:01-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52480"
+    }, {
+        "text": "%md\nThen we load in the packages we need.",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:04:48-0700",
+        "config": {
+            "tableHide": false,
+            "editorSetting": {
+                "language": "markdown",
+                "editOnDblClick": true,
+                "completionKey": "TAB",
+                "completionSupport": false
+            },
+            "colWidth": 12,
+            "editorMode": "ace/mode/markdown",
+            "fontSize": 9,
+            "editorHide": true,
+            "results": {},
+            "enabled": true
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "HTML",
+                "data": "<div class=\"markdown-body\">\n<p>Then we load in the packages we need.</p>\n</div>"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559099163554_-1379713240",
+        "id": "20190524-162946_1779279677",
+        "dateCreated": "2019-05-28T20:06:03-0700",
+        "dateStarted": "2019-05-29T22:04:49-0700",
+        "dateFinished": "2019-05-29T22:04:49-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52481"
+    }, {
+        "text": "import com.microsoft.ml.spark.{TrainRegressor, TrainedRegressorModel, ComputeModelStatistics, ComputePerInstanceStatistics}\nimport scala.io.Source\nimport org.apache.spark.sql.{Dataset, SparkSession}\nimport spark.implicits._\nimport org.apache.spark.sql.types._\nimport org.apache.spark.ml.regression.LinearRegression\nimport org.apache.spark.ml.feature.StringIndexer",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:08:51-0700",
+        "config": {
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "colWidth": 12,
+            "editorMode": "ace/mode/scala",
+            "fontSize": 9,
+            "results": {},
+            "enabled": true
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TEXT",
+                "data": "import com.microsoft.ml.spark.{TrainRegressor, TrainedRegressorModel, ComputeModelStatistics, ComputePerInstanceStatistics}\nimport scala.io.Source\nimport org.apache.spark.sql.{Dataset, SparkSession}\nimport spark.implicits._\nimport org.apache.spark.sql.types._\nimport org.apache.spark.ml.regression.LinearRegression\nimport org.apache.spark.ml.feature.StringIndexer\n"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559099163554_2012353337",
+        "id": "20190523-172503_672281001",
+        "dateCreated": "2019-05-28T20:06:03-0700",
+        "dateStarted": "2019-05-29T22:08:52-0700",
+        "dateFinished": "2019-05-29T22:08:53-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52482"
+    }, {
+        "text": "val dataFilePath = \"On_Time_Performance_2012_9.csv\"\nval buffer = scala.io.Source.fromURL(\"https://mmlspark.azureedge.net/datasets/\" + dataFilePath)\nval lines = (for (line <- buffer.getLines()) yield line).toArray\nval csvDS = sc.parallelize(lines).toDS\nval flightDelay = spark.read.option(\"header\", true).option(\"inferSchema\",true).csv(csvDS)\nprintln(s\"Records Read: \"+flightDelay.count().toString)\nprintln(\"Schema: \")\nflightDelay.printSchema()\nz.show(flightDelay.limit(10))",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:04:55-0700",
+        "config": {
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "colWidth": 12,
+            "editorMode": "ace/mode/scala",
+            "fontSize": 9,
+            "results": {
+                "0": {
+                    "graph": {
+                        "mode": "table",
+                        "height": 300,
+                        "optionOpen": false,
+                        "setting": {
+                            "table": {
+                                "tableGridState": {},
+                                "tableColumnTypeState": {
+                                    "names": {
+                                        "Quarter": "string",
+                                        "Month": "string",
+                                        "DayofMonth": "string",
+                                        "DayOfWeek": "string",
+                                        "Carrier": "string",
+                                        "OriginAirportID": "string",
+                                        "DestAirportID": "string",
+                                        "CRSDepTime": "string",
+                                        "DepTimeBlk": "string",
+                                        "CRSArrTime": "string",
+                                        "ArrDelay": "string",
+                                        "ArrTimeBlk": "string",
+                                        "Diverted": "string"
+                                    },
+                                    "updated": false
+                                },
+                                "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                                "tableOptionValue": {
+                                    "useFilter": false,
+                                    "showPagination": false,
+                                    "showAggregationFooter": false
+                                },
+                                "updated": false,
+                                "initialized": false
+                            }
+                        },
+                        "commonSetting": {}
+                    }
+                },
+                "1": {
+                    "graph": {
+                        "mode": "table",
+                        "height": 300,
+                        "optionOpen": false,
+                        "setting": {
+                            "table": {
+                                "tableGridState": {},
+                                "tableColumnTypeState": {
+                                    "names": {
+                                        "Quarter": "string",
+                                        "Month": "string",
+                                        "DayofMonth": "string",
+                                        "DayOfWeek": "string",
+                                        "Carrier": "string",
+                                        "OriginAirportID": "string",
+                                        "DestAirportID": "string",
+                                        "CRSDepTime": "string",
+                                        "DepTimeBlk": "string",
+                                        "CRSArrTime": "string",
+                                        "ArrDelay": "string",
+                                        "ArrTimeBlk": "string",
+                                        "Diverted": "string"
+                                    },
+                                    "updated": false
+                                },
+                                "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                                "tableOptionValue": {
+                                    "useFilter": false,
+                                    "showPagination": false,
+                                    "showAggregationFooter": false
+                                },
+                                "updated": false,
+                                "initialized": false
+                            }
+                        },
+                        "commonSetting": {}
+                    }
+                }
+            },
+            "enabled": true
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TEXT",
+                "data": "Records Read: 490199\nSchema: \nroot\n |-- Quarter: integer (nullable = true)\n |-- Month: integer (nullable = true)\n |-- DayofMonth: integer (nullable = true)\n |-- DayOfWeek: integer (nullable = true)\n |-- Carrier: string (nullable = true)\n |-- OriginAirportID: integer (nullable = true)\n |-- DestAirportID: integer (nullable = true)\n |-- CRSDepTime: integer (nullable = true)\n |-- DepTimeBlk: string (nullable = true)\n |-- CRSArrTime: integer (nullable = true)\n |-- ArrDelay: double (nullable = true)\n |-- ArrTimeBlk: string (nullable = true)\n |-- Diverted: double (nullable = true)\n\n"
+            }, {
+                "type": "TABLE",
+                "data": "Quarter\tMonth\tDayofMonth\tDayOfWeek\tCarrier\tOriginAirportID\tDestAirportID\tCRSDepTime\tDepTimeBlk\tCRSArrTime\tArrDelay\tArrTimeBlk\tDiverted\n3\t9\t1\t6\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-28.0\t1600-1659\t0.0\n3\t9\t2\t7\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-28.0\t1600-1659\t0.0\n3\t9\t3\t1\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-27.0\t1600-1659\t0.0\n3\t9\t4\t2\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-22.0\t1600-1659\t0.0\n3\t9\t5\t3\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-6.0\t1600-1659\t0.0\n3\t9\t6\t4\tAA\t13303\t12892\t1415\t1400-1459\t1645\t12.0\t1600-1659\t0.0\n3\t9\t7\t5\tAA\t13303\t12892\t1415\t1400-1459\t1645\t28.0\t1600-1659\t0.0\n3\t9\t8\t6\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-11.0\t1600-1659\t0.0\n3\t9\t9\t7\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-15.0\t1600-1659\t0.0\n3\t9\t10\t1\tAA\t13303\t12892\t1415\t1400-1459\t1645\t-12.0\t1600-1659\t0.0\n"
+            }, {
+                "type": "TEXT",
+                "data": "dataFilePath: String = On_Time_Performance_2012_9.csv\nbuffer: scala.io.BufferedSource = empty iterator\nlines: Array[String] = Array(Quarter,Month,DayofMonth,DayOfWeek,Carrier,OriginAirportID,DestAirportID,CRSDepTime,DepTimeBlk,CRSArrTime,ArrDelay,ArrTimeBlk,Diverted, 3,9,1,6,AA,13303,12892,1415,1400-1459,1645,-28.00,1600-1659,0.00, 3,9,2,7,AA,13303,12892,1415,1400-1459,1645,-28.00,1600-1659,0.00, 3,9,3,1,AA,13303,12892,1415,1400-1459,1645,-27.00,1600-1659,0.00, 3,9,4,2,AA,13303,12892,1415,1400-1459,1645,-22.00,1600-1659,0.00, 3,9,5,3,AA,13303,12892,1415,1400-1459,1645,-6.00,1600-1659,0.00, 3,9,6,4,AA,13303,12892,1415,1400-1459,1645,12.00,1600-1659,0.00, 3,9,7,5,AA,13303,12892,1415,1400-1459,1645,28.00,1600-1659,0.00, 3,9,8,6,AA,13303,12892,1415,1400-1459,1645,-11.00,1600-1659,0.00, 3,9,..."
+            }]
+        },
+        "runtimeInfos": {
+            "jobUrl": {
+                "propertyName": "jobUrl",
+                "label": "SPARK JOB",
+                "tooltip": "View in Spark web UI",
+                "group": "spark",
+                "values": ["http://192.168.29.113:4042/jobs/job?id=0", "http://192.168.29.113:4042/jobs/job?id=1", "http://192.168.29.113:4042/jobs/job?id=2", "http://192.168.29.113:4042/jobs/job?id=3"],
+                "interpreterSettingId": "spark"
+            }
+        },
+        "apps": [],
+        "jobName": "paragraph_1559099163555_-1954180162",
+        "id": "20190523-172530_1022344373",
+        "dateCreated": "2019-05-28T20:06:03-0700",
+        "dateStarted": "2019-05-29T22:05:01-0700",
+        "dateFinished": "2019-05-29T22:05:26-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52483"
+    }, {
+        "text": "%md \nSplit the dataset into train and test sets.\n",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:05:01-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {},
+            "editorSetting": {
+                "language": "markdown",
+                "editOnDblClick": true,
+                "completionKey": "TAB",
+                "completionSupport": false
+            },
+            "editorMode": "ace/mode/markdown",
+            "editorHide": true,
+            "tableHide": false
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "HTML",
+                "data": "<div class=\"markdown-body\">\n<p>Split the dataset into train and test sets.</p>\n</div>"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559150836567_-929883734",
+        "id": "20190529-102716_987579800",
+        "dateCreated": "2019-05-29T10:27:16-0700",
+        "dateStarted": "2019-05-29T22:05:01-0700",
+        "dateFinished": "2019-05-29T22:05:01-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52484"
+    }, {
+        "text": "val Array(train, test) = flightDelay.randomSplit(Array(0.75, 0.25))",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:05:02-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {},
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "editorMode": "ace/mode/scala"
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TEXT",
+                "data": "train: org.apache.spark.sql.Dataset[org.apache.spark.sql.Row] = [Quarter: int, Month: int ... 11 more fields]\ntest: org.apache.spark.sql.Dataset[org.apache.spark.sql.Row] = [Quarter: int, Month: int ... 11 more fields]\n"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559150478207_-409432779",
+        "id": "20190529-102118_2003488465",
+        "dateCreated": "2019-05-29T10:21:18-0700",
+        "dateStarted": "2019-05-29T22:05:15-0700",
+        "dateFinished": "2019-05-29T22:05:27-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52485"
+    }, {
+        "text": "%md \nTrain a regressor on dataset with l-bfgs.",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:05:08-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {},
+            "editorSetting": {
+                "language": "markdown",
+                "editOnDblClick": true,
+                "completionKey": "TAB",
+                "completionSupport": false
+            },
+            "editorMode": "ace/mode/markdown",
+            "editorHide": true,
+            "tableHide": false
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "HTML",
+                "data": "<div class=\"markdown-body\">\n<p>Train a regressor on dataset with l-bfgs.</p>\n</div>"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559163977485_732144945",
+        "id": "20190529-140617_588042181",
+        "dateCreated": "2019-05-29T14:06:17-0700",
+        "dateStarted": "2019-05-29T22:05:08-0700",
+        "dateFinished": "2019-05-29T22:05:08-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52486"
+    }, {
+        "text": "val catCols = Array(\"Carrier\", \"DepTimeBlk\", \"ArrTimeBlk\")\nval trainCat = train.cache()\nval testCat = test\n// Index categorical features\nval Array(indexedTrain, indexedTest) = for(df <- Array(trainCat, testCat)) yield catCols.foldLeft(df) {\n    case (df, catCol) => \n    val simodel = new StringIndexer().setInputCol(catCol).setOutputCol(catCol+\"Tmp\").fit(train)\n    simodel.transform(df).drop(catCol).withColumnRenamed(catCol+\"Tmp\", catCol)\n}\ntrain.unpersist()\nval lr = new LinearRegression().setRegParam(0.1).setElasticNetParam(0.3)\nval model = new TrainRegressor().setModel(lr).setLabelCol(\"ArrDelay\").fit(trainCat)\n// Save as needed\n// model.write().overwrite().save(\"flightDelayModel.mml\")",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:05:09-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {},
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "editorMode": "ace/mode/scala"
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TEXT",
+                "data": "catCols: Array[String] = Array(Carrier, DepTimeBlk, ArrTimeBlk)\ntrainCat: train.type = [Quarter: int, Month: int ... 11 more fields]\ntestCat: org.apache.spark.sql.Dataset[org.apache.spark.sql.Row] = [Quarter: int, Month: int ... 11 more fields]\nindexedTrain: org.apache.spark.sql.Dataset[org.apache.spark.sql.Row] = [Quarter: int, Month: int ... 11 more fields]\nindexedTest: org.apache.spark.sql.Dataset[org.apache.spark.sql.Row] = [Quarter: int, Month: int ... 11 more fields]\nlr: org.apache.spark.ml.regression.LinearRegression = linReg_f477b8daaf0d\nmodel: com.microsoft.ml.spark.TrainedRegressorModel = TrainRegressor_83b28003a7de\n"
+            }]
+        },
+        "runtimeInfos": {
+            "jobUrl": {
+                "propertyName": "jobUrl",
+                "label": "SPARK JOB",
+                "tooltip": "View in Spark web UI",
+                "group": "spark",
+                "values": ["http://192.168.29.113:4042/jobs/job?id=4", "http://192.168.29.113:4042/jobs/job?id=5", "http://192.168.29.113:4042/jobs/job?id=6", "http://192.168.29.113:4042/jobs/job?id=7", "http://192.168.29.113:4042/jobs/job?id=8", "http://192.168.29.113:4042/jobs/job?id=9", "http://192.168.29.113:4042/jobs/job?id=10", "http://192.168.29.113:4042/jobs/job?id=11", "http://192.168.29.113:4042/jobs/job?id=12", "http://192.168.29.113:4042/jobs/job?id=13", "http://192.168.29.113:4042/jobs/job?id=14", "http://192.168.29.113:4042/jobs/job?id=15"],
+                "interpreterSettingId": "spark"
+            }
+        },
+        "apps": [],
+        "jobName": "paragraph_1559102269462_-1188419062",
+        "id": "20190528-205749_560374713",
+        "dateCreated": "2019-05-28T20:57:49-0700",
+        "dateStarted": "2019-05-29T22:05:26-0700",
+        "dateFinished": "2019-05-29T22:05:49-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52487"
+    }, {
+        "text": "%md\nScore regressor on the test data.",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:10:49-0700",
+        "config": {
+            "editorSetting": {
+                "language": "markdown",
+                "editOnDblClick": true,
+                "completionKey": "TAB",
+                "completionSupport": false
+            },
+            "colWidth": 12,
+            "editorMode": "ace/mode/markdown",
+            "fontSize": 9,
+            "results": {},
+            "enabled": true,
+            "editorHide": true,
+            "tableHide": false
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "HTML",
+                "data": "<div class=\"markdown-body\">\n<p>Score regressor on the test data.</p>\n</div>"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559099163556_1672061863",
+        "id": "20190524-151811_1456028740",
+        "dateCreated": "2019-05-28T20:06:03-0700",
+        "dateStarted": "2019-05-29T22:10:49-0700",
+        "dateFinished": "2019-05-29T22:10:49-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52488"
+    }, {
+        "text": "// Can also load saved model\n// val flightDelayModel = TrainedRegressorModel.load(\"flightDelayModel.mml\")\nval scoredData = model.transform(testCat)\nz.show(scoredData.limit(10))",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:06:46-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {
+                "0": {
+                    "graph": {
+                        "mode": "table",
+                        "height": 300,
+                        "optionOpen": false,
+                        "setting": {
+                            "table": {
+                                "tableGridState": {},
+                                "tableColumnTypeState": {
+                                    "names": {
+                                        "Quarter": "string",
+                                        "Month": "string",
+                                        "DayofMonth": "string",
+                                        "DayOfWeek": "string",
+                                        "Carrier": "string",
+                                        "OriginAirportID": "string",
+                                        "DestAirportID": "string",
+                                        "CRSDepTime": "string",
+                                        "DepTimeBlk": "string",
+                                        "CRSArrTime": "string",
+                                        "ArrDelay": "string",
+                                        "ArrTimeBlk": "string",
+                                        "Diverted": "string",
+                                        "scores": "string"
+                                    },
+                                    "updated": false
+                                },
+                                "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                                "tableOptionValue": {
+                                    "useFilter": false,
+                                    "showPagination": false,
+                                    "showAggregationFooter": false
+                                },
+                                "updated": false,
+                                "initialized": false
+                            }
+                        },
+                        "commonSetting": {}
+                    }
+                }
+            },
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "editorMode": "ace/mode/scala"
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TABLE",
+                "data": "Quarter\tMonth\tDayofMonth\tDayOfWeek\tCarrier\tOriginAirportID\tDestAirportID\tCRSDepTime\tDepTimeBlk\tCRSArrTime\tArrDelay\tArrTimeBlk\tDiverted\tscores\n3\t9\t1\t6\tAA\t10397\t11298\t600\t0600-0659\t710\t-11.0\t0700-0759\t0.0\t13.056630500563939\n3\t9\t1\t6\tAA\t10397\t11298\t745\t0700-0759\t915\t-16.0\t0900-0959\t0.0\t15.503816685587191\n3\t9\t1\t6\tAA\t10397\t11298\t1245\t1200-1259\t1405\t-15.0\t1400-1459\t0.0\t20.80583979242722\n3\t9\t1\t6\tAA\t10397\t13303\t640\t0600-0659\t830\t7.0\t0800-0859\t0.0\t13.924347838808574\n3\t9\t1\t6\tAA\t10397\t13303\t1410\t1400-1459\t1615\t-11.0\t1600-1659\t0.0\t22.409626729866353\n3\t9\t1\t6\tAA\t10423\t11298\t830\t0800-0859\t935\t-6.0\t0900-0959\t0.0\t16.41478342793144\n3\t9\t1\t6\tAA\t10423\t11298\t1100\t1100-1159\t1210\t-20.0\t1200-1259\t0.0\t18.263486334242906\n3\t9\t1\t6\tAA\t10423\t11298\t1655\t1600-1659\t1805\t-24.0\t1800-1859\t0.0\t24.028590399426584\n3\t9\t1\t6\tAA\t10423\t12892\t720\t0700-0759\t830\t4.0\t0800-0859\t0.0\t15.135652913653201\n3\t9\t1\t6\tAA\t10423\t12892\t1215\t1200-1259\t1325\t-4.0\t1300-1359\t0.0\t19.565040825749726\n"
+            }, {
+                "type": "TEXT",
+                "data": "scoredData: org.apache.spark.sql.DataFrame = [Quarter: int, Month: int ... 12 more fields]\n"
+            }]
+        },
+        "runtimeInfos": {
+            "jobUrl": {
+                "propertyName": "jobUrl",
+                "label": "SPARK JOB",
+                "tooltip": "View in Spark web UI",
+                "group": "spark",
+                "values": ["http://192.168.29.113:4042/jobs/job?id=16"],
+                "interpreterSettingId": "spark"
+            }
+        },
+        "apps": [],
+        "jobName": "paragraph_1559192754912_1184478671",
+        "id": "20190529-220554_1122344152",
+        "dateCreated": "2019-05-29T22:05:54-0700",
+        "dateStarted": "2019-05-29T22:06:43-0700",
+        "dateFinished": "2019-05-29T22:06:44-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52489"
+    }, {
+        "text": "%md\nCompute model metrics against the entire scored dataset.\n",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:10:44-0700",
+        "config": {
+            "editorSetting": {
+                "language": "markdown",
+                "editOnDblClick": true,
+                "completionKey": "TAB",
+                "completionSupport": false
+            },
+            "colWidth": 12,
+            "editorMode": "ace/mode/markdown",
+            "fontSize": 9,
+            "results": {
+                "0": {
+                    "graph": {
+                        "mode": "table",
+                        "height": 84.5,
+                        "optionOpen": false,
+                        "setting": {
+                            "table": {
+                                "tableGridState": {},
+                                "tableColumnTypeState": {
+                                    "names": {
+                                        "evaluation_type": "string",
+                                        "accuracy": "string",
+                                        "precision": "string",
+                                        "recall": "string",
+                                        "AUC": "string"
+                                    },
+                                    "updated": false
+                                },
+                                "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                                "tableOptionValue": {
+                                    "useFilter": false,
+                                    "showPagination": false,
+                                    "showAggregationFooter": false
+                                },
+                                "updated": false,
+                                "initialized": false
+                            }
+                        },
+                        "commonSetting": {}
+                    }
+                },
+                "1": {
+                    "graph": {
+                        "mode": "table",
+                        "height": 90.8,
+                        "optionOpen": false
+                    }
+                }
+            },
+            "enabled": true,
+            "editorHide": true,
+            "tableHide": false
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "HTML",
+                "data": "<div class=\"markdown-body\">\n<p>Compute model metrics against the entire scored dataset.</p>\n</div>"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559099163556_-381977855",
+        "id": "20190524-161859_1100073829",
+        "dateCreated": "2019-05-28T20:06:03-0700",
+        "dateStarted": "2019-05-29T22:10:44-0700",
+        "dateFinished": "2019-05-29T22:10:44-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52490"
+    }, {
+        "text": "val metrics = new ComputeModelStatistics().transform(scoredData)\nz.show(metrics)",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:08:15-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {
+                "0": {
+                    "graph": {
+                        "mode": "table",
+                        "height": 84.5,
+                        "optionOpen": false,
+                        "setting": {
+                            "table": {
+                                "tableGridState": {},
+                                "tableColumnTypeState": {
+                                    "names": {
+                                        "mean_squared_error": "string",
+                                        "root_mean_squared_error": "string",
+                                        "R^2": "string",
+                                        "mean_absolute_error": "string"
+                                    },
+                                    "updated": false
+                                },
+                                "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                                "tableOptionValue": {
+                                    "useFilter": false,
+                                    "showPagination": false,
+                                    "showAggregationFooter": false
+                                },
+                                "updated": false,
+                                "initialized": false
+                            }
+                        },
+                        "commonSetting": {}
+                    }
+                }
+            },
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "editorMode": "ace/mode/scala"
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TABLE",
+                "data": "mean_squared_error\troot_mean_squared_error\tR^2\tmean_absolute_error\n1162.845104316036\t34.10051472215685\t0.04207741039855739\t17.593623469677624\n"
+            }, {
+                "type": "TEXT",
+                "data": "metrics: org.apache.spark.sql.DataFrame = [mean_squared_error: double, root_mean_squared_error: double ... 2 more fields]\n"
+            }]
+        },
+        "runtimeInfos": {
+            "jobUrl": {
+                "propertyName": "jobUrl",
+                "label": "SPARK JOB",
+                "tooltip": "View in Spark web UI",
+                "group": "spark",
+                "values": ["http://192.168.29.113:4042/jobs/job?id=17"],
+                "interpreterSettingId": "spark"
+            }
+        },
+        "apps": [],
+        "jobName": "paragraph_1559192829828_1076543563",
+        "id": "20190529-220709_1557529173",
+        "dateCreated": "2019-05-29T22:07:09-0700",
+        "dateStarted": "2019-05-29T22:08:06-0700",
+        "dateFinished": "2019-05-29T22:08:08-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52491"
+    }, {
+        "text": "%md\nFinally, compute and show per-instance statistics, demonstrating the usage of ComputePerInstanceStatistics.\n",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:08:41-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {},
+            "editorSetting": {
+                "language": "markdown",
+                "editOnDblClick": true,
+                "completionKey": "TAB",
+                "completionSupport": false
+            },
+            "editorMode": "ace/mode/markdown",
+            "editorHide": true,
+            "tableHide": false
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "HTML",
+                "data": "<div class=\"markdown-body\">\n<p>Finally, compute and show per-instance statistics, demonstrating the usage of ComputePerInstanceStatistics.</p>\n</div>"
+            }]
+        },
+        "apps": [],
+        "jobName": "paragraph_1559192886228_-2132283625",
+        "id": "20190529-220806_156069832",
+        "dateCreated": "2019-05-29T22:08:06-0700",
+        "dateStarted": "2019-05-29T22:08:41-0700",
+        "dateFinished": "2019-05-29T22:08:41-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52492"
+    }, {
+        "text": "val evalPerInstance = new ComputePerInstanceStatistics().transform(scoredData)\nz.show(evalPerInstance.select(\"ArrDelay\", \"Scores\", \"L1_loss\", \"L2_loss\").limit(10))\n",
+        "user": "admin",
+        "dateUpdated": "2019-05-29T22:09:18-0700",
+        "config": {
+            "colWidth": 12,
+            "fontSize": 9,
+            "enabled": true,
+            "results": {
+                "0": {
+                    "graph": {
+                        "mode": "table",
+                        "height": 300,
+                        "optionOpen": false,
+                        "setting": {
+                            "table": {
+                                "tableGridState": {},
+                                "tableColumnTypeState": {
+                                    "names": {
+                                        "ArrDelay": "string",
+                                        "Scores": "string",
+                                        "L1_loss": "string",
+                                        "L2_loss": "string"
+                                    },
+                                    "updated": false
+                                },
+                                "tableOptionSpecHash": "[{\"name\":\"useFilter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable filter for columns\"},{\"name\":\"showPagination\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable pagination for better navigation\"},{\"name\":\"showAggregationFooter\",\"valueType\":\"boolean\",\"defaultValue\":false,\"widget\":\"checkbox\",\"description\":\"Enable a footer for displaying aggregated values\"}]",
+                                "tableOptionValue": {
+                                    "useFilter": false,
+                                    "showPagination": false,
+                                    "showAggregationFooter": false
+                                },
+                                "updated": false,
+                                "initialized": false
+                            }
+                        },
+                        "commonSetting": {}
+                    }
+                }
+            },
+            "editorSetting": {
+                "language": "scala",
+                "editOnDblClick": false,
+                "completionKey": "TAB",
+                "completionSupport": true
+            },
+            "editorMode": "ace/mode/scala"
+        },
+        "settings": {
+            "params": {},
+            "forms": {}
+        },
+        "results": {
+            "code": "SUCCESS",
+            "msg": [{
+                "type": "TABLE",
+                "data": "ArrDelay\tScores\tL1_loss\tL2_loss\n-11.0\t13.056630500563939\t24.05663050056394\t578.7214710406632\n-16.0\t15.503816685587191\t31.50381668558719\t992.4904657590818\n-15.0\t20.80583979242722\t35.80583979242722\t1282.0581632409646\n7.0\t13.924347838808574\t6.924347838808574\t47.94659299281297\n-11.0\t22.409626729866353\t33.40962672986635\t1116.2031582290003\n-6.0\t16.41478342793144\t22.41478342793144\t502.4225161210699\n-20.0\t18.263486334242906\t38.263486334242906\t1464.0943864507935\n-24.0\t24.028590399426584\t48.028590399426584\t2306.7454957558916\n4.0\t15.135652913653201\t11.135652913653201\t124.00276581335304\n-4.0\t19.565040825749726\t23.565040825749726\t555.3111491192514\n"
+            }, {
+                "type": "TEXT",
+                "data": "evalPerInstance: org.apache.spark.sql.DataFrame = [Quarter: int, Month: int ... 14 more fields]\n"
+            }]
+        },
+        "runtimeInfos": {
+            "jobUrl": {
+                "propertyName": "jobUrl",
+                "label": "SPARK JOB",
+                "tooltip": "View in Spark web UI",
+                "group": "spark",
+                "values": ["http://192.168.29.113:4042/jobs/job?id=18"],
+                "interpreterSettingId": "spark"
+            }
+        },
+        "apps": [],
+        "jobName": "paragraph_1559192921246_441013016",
+        "id": "20190529-220841_146614033",
+        "dateCreated": "2019-05-29T22:08:41-0700",
+        "dateStarted": "2019-05-29T22:09:15-0700",
+        "dateFinished": "2019-05-29T22:09:16-0700",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500,
+        "$$hashKey": "object:52493"
+    }],
+    "name": "Regression with L-BFGS",
+    "id": "2ECNZFDV1",
+    "noteParams": {},
+    "noteForms": {},
+    "angularObjects": {
+        "md:shared_process": [],
+        "spark:shared_process": []
+    },
+    "config": {
+        "isZeppelinNotebookCronEnable": false,
+        "looknfeel": "default",
+        "personalizedMode": "false"
+    },
+    "info": {}
+}


### PR DESCRIPTION
Ports two of the basic python notebook examples to scala using zeppelin notebooks. https://github.com/Azure/mmlspark/issues/453
Github doesn't have a native viewer for zeppelin, so I included instructions on how to view the files using the zepl viewer in the readme. They can also be downloaded and loaded into zeppelin to run.

Quick links here:
[Classification - Adult Census](https://github.com/kschelonka/mmlspark/blob/feature/add-scala-examples/notebooks/samples/scala/Classification%20-%20AdultCensus.json)
[Regression with L-BFGS](https://github.com/kschelonka/mmlspark/blob/feature/add-scala-examples/notebooks/samples/scala/Regression%20with%20L-BFGS.json)