### PR TITLE
adding barrier execution mode to lightgbm learners

### DIFF
--- a/docs/lightgbm.md
+++ b/docs/lightgbm.md
@@ -74,3 +74,21 @@ Models built can be saved as SparkML pipeline with native LightGBM model
 using `saveNativeModel()`. Additionally, they are fully compatible with [PMML](https://en.wikipedia.org/wiki/Predictive_Model_Markup_Language) and
 can be converted to PMML format through the
 [JPMML-SparkML-LightGBM](https://github.com/alipay/jpmml-sparkml-lightgbm) plugin.
+
+### Barrier Execution Mode
+
+By default LightGBM uses regular spark paradigm for launching tasks and communicates with the driver to coordinate task execution.
+The driver thread aggregates all task host:port information and then communicates the full list back to the workers in order for NetworkInit to be called.
+There have been some issues on certain cluster configurations because the driver needs to know how many tasks there are, and this computation is surprisingly non-trivial in spark.
+With the next v0.18 release there is a new UseBarrierExecutionMode flag, which when activated uses the barrier() stage to block all tasks.
+The barrier execution mode simplifies the logic to aggregate host:port information across all tasks, so the driver will no longer need to precompute the number of tasks in advance.
+To use it in scala, you can call setUseBarrierExecutionMode(true), for example:
+
+```
+val lgbm = new LightGBMClassifier()
+    .setLabelCol(labelColumn)
+    .setObjective(binaryObjective)
+    .setUseBarrierExecutionMode(true)
+...
+<train classifier>
+```

--- a/src/lightgbm/src/main/scala/LightGBMConstants.scala
+++ b/src/lightgbm/src/main/scala/LightGBMConstants.scala
@@ -22,4 +22,8 @@ object LightGBMConstants {
   /** Ignore worker status, used to ignore workers that get empty partitions
     */
   val ignoreStatus: String = "ignore"
+  /** Barrier execution flag telling driver that all tasks have completed
+    * sending port and host information
+    */
+  val finishedStatus: String = "finished"
 }

--- a/src/lightgbm/src/main/scala/LightGBMParams.scala
+++ b/src/lightgbm/src/main/scala/LightGBMParams.scala
@@ -5,12 +5,10 @@ package com.microsoft.ml.spark
 
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util.DefaultParamsWritable
-import org.apache.spark.sql.DataFrame
 
-/** Defines common parameters across all LightGBM learners.
+/** Defines common LightGBM execution parameters.
   */
-trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeightCol
-  with HasValidationIndicatorCol with HasInitScoreCol {
+trait LightGBMExecutionParams extends Wrappable {
   val parallelism = new Param[String](this, "parallelism",
     "Tree learner parallelism, can be set to data_parallel or voting_parallel")
   setDefault(parallelism->"data_parallel")
@@ -26,6 +24,24 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
 
   setDefault(defaultListenPort -> LightGBMConstants.defaultLocalListenPort)
 
+  val timeout = new DoubleParam(this, "timeout", "Timeout in seconds")
+  setDefault(timeout -> 1200)
+
+  def getTimeout: Double = $(timeout)
+  def setTimeout(value: Double): this.type = set(timeout, value)
+
+  val useBarrierExecutionMode = new BooleanParam(this, "useBarrierExecutionMode",
+    "Use new barrier execution mode in Beta testing, off by default.")
+  setDefault(useBarrierExecutionMode -> false)
+
+  def getUseBarrierExecutionMode: Boolean = $(useBarrierExecutionMode)
+  def setUseBarrierExecutionMode(value: Boolean): this.type = set(useBarrierExecutionMode, value)
+}
+
+/** Defines common parameters across all LightGBM learners.
+  */
+trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeightCol
+  with HasValidationIndicatorCol with HasInitScoreCol with LightGBMExecutionParams {
   val numIterations = new IntParam(this, "numIterations",
     "Number of iterations, LightGBM constructs num_class * num_iterations trees")
   setDefault(numIterations->100)
@@ -101,12 +117,6 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
 
   def getMinSumHessianInLeaf: Double = $(minSumHessianInLeaf)
   def setMinSumHessianInLeaf(value: Double): this.type = set(minSumHessianInLeaf, value)
-
-  val timeout = new DoubleParam(this, "timeout", "Timeout in seconds")
-  setDefault(timeout -> 1200)
-
-  def getTimeout: Double = $(timeout)
-  def setTimeout(value: Double): this.type = set(timeout, value)
 
   val modelString = new Param[String](this, "modelString", "LightGBM model to retrain")
   setDefault(modelString -> "")

--- a/src/lightgbm/src/test/scala/VerifyLightGBMClassifier.scala
+++ b/src/lightgbm/src/test/scala/VerifyLightGBMClassifier.scala
@@ -66,6 +66,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
       .setNumLeaves(5)
       .setNumIterations(10)
       .setObjective(binaryObjective)
+      .setUseBarrierExecutionMode(true)
 
     val paramGrid = new ParamGridBuilder()
       .addGrid(lgbm.numLeaves, Array(5, 10))


### PR DESCRIPTION
By default LightGBM uses regular spark paradigm for launching tasks and communicates with the driver to coordinate task execution.
The driver thread aggregates all task host:port information and then communicates the full list back to the workers in order for NetworkInit to be called.
There have been some issues on certain cluster configurations because the driver needs to know how many tasks there are, and this computation is surprisingly non-trivial in spark.
With the next v0.18 release there is a new UseBarrierExecutionMode flag, which when activated uses the barrier() stage to block all tasks.
The barrier execution mode simplifies the logic to aggregate host:port information across all tasks, so the driver will no longer need to precompute the number of tasks in advance.
To use it in scala, you can call setUseBarrierExecutionMode(true), for example:

```
val lgbm = new LightGBMClassifier()
    .setLabelCol(labelColumn)
    .setObjective(binaryObjective)
    .setUseBarrierExecutionMode(true)
...
<train classifier