### PR TITLE
Vowpal Wabbit on Spark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,8 @@ libraryDependencies ++= Seq(
   "com.jcraft" % "jsch" % "0.1.54",
   "com.jcraft" % "jsch" % "0.1.54",
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
-  "com.microsoft.ml.lightgbm" % "lightgbmlib" % "2.2.350"
+  "com.microsoft.ml.lightgbm" % "lightgbmlib" % "2.2.350",
+  "com.github.vowpalwabbit" %  "vw-jni" % "8.7.0"
 )
 
 lazy val IntegrationTest2 = config("it").extend(Test)

--- a/notebooks/samples/Vowpal Wabbit - Quantile Regression for Drug Discovery.ipynb
+++ b/notebooks/samples/Vowpal Wabbit - Quantile Regression for Drug Discovery.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 106 - Quantile Regression with VowpalWabbit\n",
+    "\n",
+    "We will demonstrate how to use the VowpalWabbit quantile regressor with\n",
+    "TrainRegressor and ComputeModelStatistics on the Triazines dataset.\n",
+    "\n",
+    "\n",
+    "This sample demonstrates how to use the following APIs:\n",
+    "- [`TrainRegressor`\n",
+    "  ](http://mmlspark.azureedge.net/docs/pyspark/TrainRegressor.html)\n",
+    "- [`VowpalWabbitRegressor`\n",
+    "  ](http://mmlspark.azureedge.net/docs/pyspark/VowpalWabbitRegressor.html)\n",
+    "- [`ComputeModelStatistics`\n",
+    "  ](http://mmlspark.azureedge.net/docs/pyspark/ComputeModelStatistics.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "triazines = spark.read.format(\"libsvm\")\\\n",
+    "    .load(\"wasbs://publicwasb@mmlspark.blob.core.windows.net/triazines.scale.svmlight\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print some basic info\n",
+    "print(\"records read: \" + str(triazines.count()))\n",
+    "print(\"Schema: \")\n",
+    "triazines.printSchema()\n",
+    "triazines.limit(10).toPandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split the dataset into train and test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train, test = triazines.randomSplit([0.85, 0.15], seed=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Train the quantile regressor on the training data.\n",
+    "\n",
+    "Note: have a look at stderr for the task to see VW's output\n",
+    "\n",
+    "Full command line argument docs can be found [here](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Command-Line-Arguments).\n",
+    "\n",
+    "Learning rate, numPasses and power_t are exposed to support grid search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mmlspark.vw import VowpalWabbitRegressor\n",
+    "model = (VowpalWabbitRegressor(numPasses=20, args=\"--holdout_off --loss_function quantile -q :: -l 0.1\")\n",
+    "            .fit(train))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Score the regressor on the test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoredData = model.transform(test)\n",
+    "scoredData.limit(10).toPandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute metrics using ComputeModelStatistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mmlspark.train import ComputeModelStatistics\n",
+    "metrics = ComputeModelStatistics(evaluationMetric='regression',\n",
+    "                                 labelCol='label',\n",
+    "                                 scoresCol='prediction') \\\n",
+    "            .transform(scoredData)\n",
+    "metrics.toPandas()"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -151,6 +151,8 @@ jobs:
         PACKAGE: "stages"
       train:
         PACKAGE: "train"
+      vw:
+        PACKAGE: "vw"
   steps:
     - task: AzureCLI@1
       displayName: 'Setup repo'

--- a/src/it/scala/com/microsoft/ml/nbtest/DatabricksUtilities.scala
+++ b/src/it/scala/com/microsoft/ml/nbtest/DatabricksUtilities.scala
@@ -54,7 +54,7 @@ object DatabricksUtilities {
   // MMLSpark info
   val truncatedScalaVersion: String = BuildInfo.scalaVersion
     .split(".".toCharArray.head).dropRight(1).mkString(".")
-  val version = s"com.microsoft.ml.spark:${BuildInfo.name}_$truncatedScalaVersion:0.17+85-1d8f34cf"
+  val version = s"com.microsoft.ml.spark:${BuildInfo.name}_$truncatedScalaVersion:${BuildInfo.version}"
   val repository = "https://mmlspark.azureedge.net/maven"
 
   val libraries: String = List(

--- a/src/it/scala/com/microsoft/ml/spark/codegen/PySparkWrapperTest.scala
+++ b/src/it/scala/com/microsoft/ml/spark/codegen/PySparkWrapperTest.scala
@@ -172,14 +172,18 @@ abstract class PySparkWrapperParamsTest(entryPoint: Params,
   protected def isSkippedParam(paramName: String): Boolean = skippedParams.contains(paramName)
   protected def isModel(paramName: String): Boolean = paramName.toLowerCase() == "model"
   protected def isBaseTransformer(paramName: String): Boolean = paramName.toLowerCase() == "basetransformer"
-  protected def tryFitString(entryPointName: String): String =
-    if (entryPointName.contains("Regressor") && !entryPointName.contains("LightGBM"))
+  protected def tryFitString(entryPointName: String): String = {
+    //TODO Remove all of this and refactor codegen
+    if (entryPointName.contains("LightGBM") || entryPointName.contains("VowpalWabbit"))
+      ""
+    else if (entryPointName.contains("Regressor"))
       tryFitTemplate(entryPointName, "LinearRegression(solver=\"l-bfgs\")")
-    else if (entryPointName.contains("Classifier") && !entryPointName.contains("LightGBM"))
+    else if (entryPointName.contains("Classifier"))
       tryFitTemplate(entryPointName, "LogisticRegression()")
     else if (entryPointName.contains("MultiColumnAdapter"))
       tryMultiColumnFitTemplate(entryPointName, "ValueIndexer()")
     else ""
+  }
   protected def computeStatisticsString(entryPointName: String): String = computeStatisticsTemplate(entryPointName)
   protected def evaluateString(entryPointName: String): String          = evaluateTemplate(entryPointName)
   protected def indexToValueString(entryPointName: String): String      = indexToValueTemplate(entryPointName)

--- a/src/main/scala/com/microsoft/ml/spark/core/utils/ClusterUtil.scala
+++ b/src/main/scala/com/microsoft/ml/spark/core/utils/ClusterUtil.scala
@@ -1,0 +1,96 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.core.utils
+
+import java.net.InetAddress
+
+import org.apache.http.conn.util.InetAddressUtils
+import org.apache.spark.lightgbm.BlockManagerUtils
+import org.apache.spark.sql.Dataset
+import org.slf4j.Logger
+
+object ClusterUtil {
+  /** Get number of cores from dummy dataset for 1 executor.
+    * Note: all executors have same number of cores,
+    * and this is more reliable than getting value from conf.
+    * @param dataset The dataset containing the current spark session.
+    * @return The number of cores per executor.
+    */
+  def getNumCoresPerExecutor(dataset: Dataset[_], log: Logger): Int = {
+    val spark = dataset.sparkSession
+    val confTaskCpus =
+      try {
+        spark.sparkContext.getConf.get("spark.task.cpus", "1").toInt
+      } catch {
+        case _: NoSuchElementException => 1
+      }
+    try {
+      val confCores = spark.sparkContext.getConf
+        .get("spark.executor.cores").toInt
+      val coresPerExec = confCores / confTaskCpus
+      log.info(s"LightGBM calculated num cores per executor as $coresPerExec from $confCores " +
+        s"cores and $confTaskCpus task CPUs")
+      coresPerExec
+    } catch {
+      case _: NoSuchElementException =>
+        // If spark.executor.cores is not defined, get the cores per JVM
+        import spark.implicits._
+        val numMachineCores = spark.range(0, 1)
+          .map(_ => java.lang.Runtime.getRuntime.availableProcessors).collect.head
+        val coresPerExec = numMachineCores / confTaskCpus
+        log.info(s"LightGBM calculated num cores per executor as $coresPerExec from " +
+          s"$numMachineCores machine cores from JVM and $confTaskCpus task CPUs")
+        coresPerExec
+    }
+  }
+
+  def getDriverHost(dataset: Dataset[_]): String = {
+    val blockManager = BlockManagerUtils.getBlockManager(dataset)
+    blockManager.master.getMemoryStatus.toList.flatMap({ case (blockManagerId, _) =>
+      if (blockManagerId.executorId == "driver") Some(getHostToIP(blockManagerId.host))
+      else None
+    }).head
+  }
+
+  def getHostToIP(hostname: String): String = {
+    if (InetAddressUtils.isIPv4Address(hostname) || InetAddressUtils.isIPv6Address(hostname))
+      hostname
+    else
+      InetAddress.getByName(hostname).getHostAddress
+  }
+
+  /** Returns a list of executor id and host.
+    * @param dataset The dataset containing the current spark session.
+    * @return List of executors as an array of (id,host).
+    */
+  def getExecutors(dataset: Dataset[_]): Array[(Int, String)] = {
+    val blockManager = BlockManagerUtils.getBlockManager(dataset)
+    blockManager.master.getMemoryStatus.toList.flatMap({ case (blockManagerId, _) =>
+      if (blockManagerId.executorId == "driver") None
+      else Some((blockManagerId.executorId.toInt, getHostToIP(blockManagerId.host)))
+    }).toArray
+  }
+
+  /** Returns the number of executors * number of cores.
+    * @param dataset The dataset containing the current spark session.
+    * @param numCoresPerExec The number of cores per executor.
+    * @return The number of executors * number of cores.
+    */
+  def getNumExecutorCores(dataset: Dataset[_], numCoresPerExec: Int): Int = {
+    val executors = getExecutors(dataset)
+    if (!executors.isEmpty) {
+      executors.length * numCoresPerExec
+    } else {
+      val master = dataset.sparkSession.sparkContext.master
+      val rx = "local(?:\\[(\\*|\\d+)(?:,\\d+)?\\])?".r
+      master match {
+        case rx(null)  => 1
+        case rx("*")   => Runtime.getRuntime.availableProcessors()
+        case rx(cores) => cores.toInt
+        case _         => BlockManagerUtils.getBlockManager(dataset)
+          .master.getMemoryStatus.size
+      }
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/core/utils/ContextObjectInputStream.scala
+++ b/src/main/scala/com/microsoft/ml/spark/core/utils/ContextObjectInputStream.scala
@@ -1,0 +1,16 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.core.utils
+
+import java.io.{InputStream, ObjectInputStream, ObjectStreamClass}
+
+class ContextObjectInputStream(input: InputStream) extends ObjectInputStream(input) {
+  protected override def resolveClass(desc: ObjectStreamClass): Class[_] = {
+    try {
+      Class.forName(desc.getName, false, Thread.currentThread().getContextClassLoader)
+    } catch {
+      case _: ClassNotFoundException => super.resolveClass(desc)
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
@@ -3,6 +3,7 @@
 
 package com.microsoft.ml.spark.lightgbm
 
+import com.microsoft.ml.spark.core.utils.ClusterUtil
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.sql.{DataFrame, Dataset, Encoders}
 
@@ -40,8 +41,8 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
 
   protected def innerTrain(dataset: Dataset[_]): TrainedModel = {
     val sc = dataset.sparkSession.sparkContext
-    val numCoresPerExec = LightGBMUtils.getNumCoresPerExecutor(dataset, log)
-    val numExecutorCores = LightGBMUtils.getNumExecutorCores(dataset, numCoresPerExec)
+    val numCoresPerExec = ClusterUtil.getNumCoresPerExecutor(dataset, log)
+    val numExecutorCores = ClusterUtil.getNumExecutorCores(dataset, numCoresPerExec)
     val numWorkers = min(numExecutorCores, dataset.rdd.getNumPartitions)
     // Only get the relevant columns
     val trainingCols = ListBuffer(getLabelCol, getFeaturesCol)

--- a/src/main/scala/com/microsoft/ml/spark/vw/HasNumBits.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/HasNumBits.scala
@@ -1,0 +1,32 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import org.apache.spark.ml.param.{BooleanParam, IntParam}
+import com.microsoft.ml.spark.core.contracts.Wrappable
+
+/** Controls hashing parameters such us number of bits (numbits) and how to handle collisions.
+  */
+trait HasNumBits extends Wrappable {
+  val numbits = new IntParam(this, "numbits", "Number of bits used to mask")
+  setDefault(numbits -> 30)
+
+  def getNumBits: Int = $(numbits)
+  def setNumBits(value: Int): this.type = {
+    if (value < 1 || value > 30)
+      throw new IllegalArgumentException("Number of bits must be between 1 and 30 bits")
+    set(numbits, value)
+  }
+
+  /**
+    * @return the bitmask used to constrain the hash feature indices.
+    */
+  protected def getMask: Int = ((1 << getNumBits) - 1)
+
+  val sumCollisions = new BooleanParam(this, "sumCollisions", "Sums collisions if true, otherwise removes them")
+  setDefault(sumCollisions -> true)
+
+  def getSumCollisions: Boolean = $(sumCollisions)
+  def setSumCollisions(value: Boolean): this.type = set(sumCollisions, value)
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/VectorUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/VectorUtils.scala
@@ -1,0 +1,62 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+object VectorUtils {
+  /**
+    * Sort indices and associated values. Either sums or ignores values for collisions.
+    * @param indices indices to be sorted.
+    * @param values associated values to each index.
+    * @param sumCollisions if true values of index collisions are summed, otherwise ignored.
+    * @return
+    */
+  def sortAndDistinct(indices: Array[Int], values: Array[Double], sumCollisions: Boolean = true):
+  (Array[Int], Array[Double]) = {
+    if (indices.length <= 0)
+      (indices, values)
+    else {
+      // get a sorted list of indices
+      val argsort = (0 until indices.length)
+        .sortWith(indices(_) < indices(_))
+        .toArray
+
+      val indicesSorted = new Array[Int](indices.length)
+      val valuesSorted = new Array[Double](indices.length)
+
+      indicesSorted(0) = indices(argsort(0))
+      var previousIndex = indicesSorted(0)
+      valuesSorted(0) = values(argsort(0))
+
+      // in-place de-duplicate
+      var j = 1
+      for (i <- 1 until indices.length) {
+        val argIndex = argsort(i)
+        val index = indices(argIndex)
+
+        if (index != previousIndex) {
+          indicesSorted(j) = index
+          previousIndex = index
+          valuesSorted(j) = values(argIndex)
+
+          j += 1
+        }
+        else if (sumCollisions)
+          valuesSorted(j - 1) += values(argIndex)
+      }
+
+      if (j == indices.length)
+        (indicesSorted, valuesSorted)
+      else {
+        // just in case we found duplicates, lets compact the array
+        val indicesCompacted = new Array[Int](j)
+        val valuesCompacted = new Array[Double](j)
+
+        Array.copy(indicesSorted, 0, indicesCompacted, 0, j)
+        Array.copy(valuesSorted, 0, valuesCompacted, 0, j)
+
+        (indicesCompacted, valuesCompacted)
+      }
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitBase.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitBase.scala
@@ -1,0 +1,372 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import java.util.UUID
+
+import org.apache.spark.TaskContext
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.util.DefaultParamsWritable
+import org.apache.spark.sql.functions.{col, struct, udf}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Dataset, Encoders, Row}
+import org.apache.spark.internal._
+import org.vowpalwabbit.spark.prediction.ScalarPrediction
+import org.vowpalwabbit.spark.{ClusterSpanningTree, VowpalWabbitExample, VowpalWabbitMurmur, VowpalWabbitNative}
+import com.microsoft.ml.spark.core.contracts.{HasWeightCol, Wrappable}
+import com.microsoft.ml.spark.core.env.{InternalWrapper, StreamUtilities}
+import com.microsoft.ml.spark.core.utils.ClusterUtil
+import org.apache.spark.ml.ComplexParamsWritable
+
+import scala.math.min
+
+case class NamespaceInfo (hash: Int, featureGroup: Char, colIdx: Int)
+
+/**
+  * VW support multiple input columns which are mapped to namespaces.
+  * Note: when one wants to create quadratic features within VW you'd specify additionalFeatures.
+  * Each feature column is treated as one namespace. Using -q 'uc' for columns 'user' and 'content'
+  * you'd get all quadratics for features in user/content
+  * (the first letter is called feature group and VW users are used to it... before somebody starts complaining ;)
+  */
+trait HasAdditionalFeatures extends Wrappable {
+  val additionalFeatures = new StringArrayParam(this, "additionalFeatures", "Additional feature columns")
+
+  def getAdditionalFeatures: Array[String] = $(additionalFeatures)
+  def setAdditionalFeatures(value: Array[String]): this.type = set(additionalFeatures, value)
+}
+
+/**
+  * Base implementation of VowpalWabbit learners.
+  *
+  * @note parameters that regularly are swept through are exposed as proper parameters.
+  */
+@InternalWrapper
+trait VowpalWabbitBase extends Wrappable
+  with DefaultParamsWritable
+  with HasWeightCol
+  with HasAdditionalFeatures
+  with Logging
+{
+  // can we switch to use meta programming (https://docs.scala-lang.org/overviews/macros/paradise.html)
+  // to generate all the parameters?
+  val args = new Param[String](this, "args", "VW command line arguments passed")
+  setDefault(args -> "")
+
+  def getArgs: String = $(args)
+  def setArgs(value: String): this.type = set(args, value)
+
+  setDefault(additionalFeatures -> Array())
+
+  // to support Grid search we need to replicate the parameters here...
+  val numPasses = new IntParam(this, "numPasses", "Number of passes over the data")
+  setDefault(numPasses -> 1)
+  def getNumPasses: Int = $(numPasses)
+  def setNumPasses(value: Int): this.type = set(numPasses, value)
+
+  // Note on parameters: default values are set in the C++ codebase. To avoid replication
+  // and potentially introduce conflicting default values, the Scala exposed parameters
+  // are only passed to the native side if they're set.
+
+  val learningRate = new DoubleParam(this, "learningRate", "Learning rate")
+  def getLearningRate: Double = $(learningRate)
+  def setLearningRate(value: Double): this.type = set(learningRate, value)
+
+  val powerT = new DoubleParam(this, "powerT", "t power value")
+  def getPowerT: Double = $(powerT)
+  def setPowerT(value: Double): this.type = set(powerT, value)
+
+  val l1 = new DoubleParam(this, "l1", "l_1 lambda")
+  def getL1: Double = $(l1)
+  def setL1(value: Double): this.type = set(l1, value)
+
+  val l2 = new DoubleParam(this, "l2", "l_2 lambda")
+  def getL2: Double = $(l2)
+  def setL2(value: Double): this.type = set(l2, value)
+
+  val interactions = new StringArrayParam(this, "interactions", "Interaction terms as specified by -q")
+  def getInteractions: Array[String] = $(interactions)
+  def setInteractions(value: Array[String]): this.type = set(interactions, value)
+
+  val ignoreNamespaces = new Param[String](this, "ignoreNamespaces", "Namespaces to be ignored (first letter only)")
+  def getIgnoreNamespaces: String = $(ignoreNamespaces)
+  def setIgnoreNamespaces(value: String): this.type = set(ignoreNamespaces, value)
+
+  val initialModel = new ByteArrayParam(this, "initialModel", "Initial model to start from")
+  def getInitialModel: Array[Byte] = $(initialModel)
+  def setInitialModel(value: Array[Byte]): this.type = set(initialModel, value)
+
+  // abstract methods that implementors need to provide (mixed in through Classifier,...)
+  def getLabelCol: String
+  def getFeaturesCol: String
+
+  implicit class ParamStringBuilder(sb: StringBuilder) {
+    def appendParam[T](param: Param[T], option: String): StringBuilder = {
+      if (!get(param).isEmpty) {
+
+        param match {
+          case _: StringArrayParam => {
+            for (q <- get(param).get)
+              sb.append(s" $option $q")
+          }
+          case _ => sb.append(s" $option ${get(param).get}")
+        }
+      }
+
+      sb
+    }
+  }
+
+  val hashSeed = new IntParam(this, "hashSeed", "Seed used for hashing")
+  setDefault(hashSeed -> 0)
+
+  def getHashSeed: Int = $(hashSeed)
+  def setHashSeed(value: Int): this.type = set(hashSeed, value)
+
+  val numBits = new IntParam(this, "numBits", "Number of bits used")
+  setDefault(numBits -> 18)
+
+  def getNumBits: Int = $(numBits)
+  def setNumBits(value: Int): this.type = set(numBits, value)
+
+  private def createLabelSetter(df: DataFrame) = {
+    val labelColIdx = df.schema.fieldIndex(getLabelCol)
+
+    if (get(weightCol).isDefined) {
+      val weightColIdx = df.schema.fieldIndex(getWeightCol)
+      (row: Row, ex: VowpalWabbitExample) =>
+        ex.setLabel(row.getDouble(weightColIdx).toFloat, row.getDouble(labelColIdx).toFloat)
+    }
+    else
+      (row: Row, ex: VowpalWabbitExample) => ex.setLabel(row.getDouble(labelColIdx).toFloat)
+  }
+
+  /**
+    * Generate namespace info (hash, feature group, field index) for supplied columns.
+    * @param schema data frame schema to lookup column indices.
+    * @return
+    */
+  private def generateNamespaceInfos(schema: StructType): Array[NamespaceInfo] =
+    (Seq(getFeaturesCol) ++ getAdditionalFeatures)
+      .map(col => new NamespaceInfo(VowpalWabbitMurmur.hash(col, getHashSeed), col.charAt(0), schema.fieldIndex(col)))
+      .toArray
+
+  private def buildCommandLineArguments(vwArgs: String, contextArgs: => String = "") = {
+    val args = new StringBuilder
+    args.append(vwArgs)
+      .append(" ").append(contextArgs)
+
+    // have to pass to get multi-pass to work
+    val noStdin = "--no_stdin"
+    if (args.indexOf(noStdin) == -1)
+      args.append(" ").append(noStdin)
+
+    // need to keep reference around to prevent GC and subsequent file delete
+    if (getNumPasses > 1) {
+      val cacheFile = java.io.File.createTempFile("vowpalwabbit", ".cache")
+      cacheFile.deleteOnExit()
+
+      args.append(s" -k --cache_file=${cacheFile.getAbsolutePath} --passes ${getNumPasses}")
+    }
+
+    log.info(s"VowpalWabbit args: ${args}")
+
+    args.result
+  }
+
+  /**
+    * Internal training loop.
+    * @param df the input data frame.
+    * @param vwArgs vw command line arguments.
+    * @param contextArgs This lambda returns command line arguments that are executed in the final execution context.
+    *                    It is used to get the partition id.
+    */
+  private def trainInternal(df: DataFrame, vwArgs: String, contextArgs: => String = "") = {
+    val applyLabel = createLabelSetter(df)
+
+    val featureColIndices = generateNamespaceInfos(df.schema)
+
+    def trainIteration(inputRows: Iterator[Row],
+                       localInitialModel: Option[Array[Byte]]): Iterator[Option[Array[Byte]]] = {
+
+      // construct command line arguments
+      val args = buildCommandLineArguments(vwArgs, contextArgs)
+
+      StreamUtilities.using(if (localInitialModel.isEmpty) new VowpalWabbitNative(args)
+        else new VowpalWabbitNative(args, localInitialModel.get)) { vw =>
+        StreamUtilities.using(vw.createExample()) { ex =>
+            // pass data to VW native part
+            for (row <- inputRows) {
+              // transfer label
+              applyLabel(row, ex)
+
+              // transfer features
+              for (ns <- featureColIndices)
+                row.get(ns.colIdx) match {
+                  case dense: DenseVector => ex.addToNamespaceDense(ns.featureGroup,
+                    ns.hash, dense.values)
+                  case sparse: SparseVector => ex.addToNamespaceSparse(ns.featureGroup,
+                    sparse.indices, sparse.values)
+                }
+
+              ex.learn
+              ex.clear
+            }
+
+            vw.endPass
+
+            if (getNumPasses > 1)
+              vw.performRemainingPasses
+          }
+
+          // only export the model on the first partition
+          Seq(if (TaskContext.get.partitionId == 0) Some(vw.getModel) else None).iterator
+        }.get // this will throw if there was an exception
+    }
+
+    val encoder = Encoders.kryo[Option[Array[Byte]]]
+
+    // schedule multiple mapPartitions in
+    var localInitialModel = if (isDefined(initialModel)) Some(getInitialModel) else None
+
+    // dispatch to exectuors and collect the model of the first partition (everybody has the same at the end anyway)
+    df.mapPartitions(inputRows => trainIteration(inputRows, localInitialModel))(encoder)
+      .reduce((a, b) => if (a.isEmpty) b else a)
+  }
+
+  /**
+    * Setup spanning tree and invoke training.
+    * @param df input data.
+    * @param vwArgs VW command line arguments.
+    * @param numWorkers number of target workers.
+    * @return
+    */
+  protected def trainInternalDistributed(df: DataFrame, vwArgs: StringBuilder, numWorkers: Int) = {
+    // multiple partitions -> setup distributed coordination
+    val spanningTree = new ClusterSpanningTree(0, getArgs.contains("--quiet"))
+
+    try {
+      spanningTree.start
+
+      val jobUniqueId = Math.abs(UUID.randomUUID.getLeastSignificantBits.toInt)
+      val driverHostAddress = ClusterUtil.getDriverHost(df)
+      val port = spanningTree.getPort
+
+      /*
+      --span_server specifies the network address of a little server that sets up spanning trees over the nodes.
+      --unique_id should be a number that is the same for all nodes executing a particular job and
+        different for all others.
+      --total is the total number of nodes.
+      --node should be unique for each node and range from {0,total-1}.
+      --holdout_off should be included for distributed training
+      */
+      vwArgs.append(s" --holdout_off --span_server $driverHostAddress --span_server_port $port ")
+        .append(s"--unique_id $jobUniqueId --total $numWorkers ")
+
+      trainInternal(df, vwArgs.result, s"--node ${TaskContext.get.partitionId}")
+    } finally {
+      spanningTree.stop
+    }
+  }
+
+  /**
+    * Main training loop
+    * @param dataset input data.
+    * @return binary VW model.
+    */
+  protected def trainInternal(dataset: Dataset[_]): Array[Byte] = {
+    // follow LightGBM pattern
+    val numCoresPerExec = ClusterUtil.getNumCoresPerExecutor(dataset, log)
+    val numExecutorCores = ClusterUtil.getNumExecutorCores(dataset, numCoresPerExec)
+    val numWorkers = min(numExecutorCores, dataset.rdd.getNumPartitions)
+
+    // Select needed columns, maybe get the weight column, keeps mem usage low
+    val dfSubset = dataset.toDF().select((
+        Seq(getFeaturesCol, getLabelCol) ++
+        getAdditionalFeatures ++
+        Seq(get(weightCol)).flatten
+      ).map(col): _*)
+
+    // Reduce number of partitions to number of executor cores
+    val df = if (dataset.rdd.getNumPartitions > numWorkers)
+        dfSubset.coalesce(numWorkers)
+      else
+        dfSubset
+
+    // add exposed parameters to the final command line args
+    val vwArgs = new StringBuilder()
+      .append(s"${getArgs} --save_resume --preserve_performance_counters ")
+      .append(s"--hash_seed ${getHashSeed} ")
+      .append(s"-b ${getNumBits} ")
+      .appendParam(learningRate, "-l")
+      .appendParam(powerT, "--power_t")
+      .appendParam(l1, "--l1")
+      .appendParam(l2, "--l2")
+      .appendParam(ignoreNamespaces, "--ignore")
+      .appendParam(interactions, "-q")
+
+    // call training
+    val binaryModel = if (numWorkers == 1)
+      trainInternal(df, vwArgs.result)
+    else
+      trainInternalDistributed(df, vwArgs, numWorkers)
+
+    binaryModel.get
+  }
+}
+
+/**
+  * Base trait to wrap the model for prediction.
+  */
+trait VowpalWabbitBaseModel extends org.apache.spark.ml.param.shared.HasFeaturesCol
+  with org.apache.spark.ml.param.shared.HasRawPredictionCol
+  with HasAdditionalFeatures
+  with ComplexParamsWritable
+{
+  @transient
+  lazy val vw = new VowpalWabbitNative("--testonly --quiet", getModel)
+
+  @transient
+  lazy val example = vw.createExample()
+
+  @transient
+  lazy val vwArgs = vw.getArguments
+
+  protected def transformImplInternal(dataset: Dataset[_]): DataFrame = {
+    val featureColIndices = (Seq(getFeaturesCol) ++ getAdditionalFeatures)
+      .zipWithIndex.map { case (col, index) => new NamespaceInfo(
+        VowpalWabbitMurmur.hash(col, vwArgs.getHashSeed),
+        col.charAt(0),
+        index)
+    }
+
+    val predictUDF = udf { (namespaces: Row) => predictInternal(featureColIndices, namespaces) }
+
+    val allCols = Seq(col($(featuresCol))) ++ getAdditionalFeatures.map(col)
+
+    dataset.withColumn($(rawPredictionCol), predictUDF(struct(allCols: _*)))
+  }
+
+  val model = new ByteArrayParam(this, "model", "The VW model....")
+
+  def setModel(v: Array[Byte]): this.type = set(model, v)
+
+  def getModel: Array[Byte] = $(model)
+
+  protected def predictInternal(featureColIndices: Seq[NamespaceInfo], namespaces: Row): Double = {
+    example.clear
+
+    for (ns <- featureColIndices)
+      namespaces.get(ns.colIdx) match {
+        case dense: DenseVector => example.addToNamespaceDense(ns.featureGroup,
+          ns.hash, dense.values)
+        case sparse: SparseVector => example.addToNamespaceSparse(ns.featureGroup,
+          sparse.indices, sparse.values)
+      }
+
+    // TODO: surface prediction confidence
+    example.predict.asInstanceOf[ScalarPrediction].getValue.toDouble
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitClassifier.scala
@@ -1,0 +1,82 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.serialize.ConstructorReadable
+import org.apache.spark.ml.ComplexParamsReadable
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.util._
+import org.apache.spark.ml.classification.{ProbabilisticClassificationModel, ProbabilisticClassifier}
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{col, udf}
+
+import scala.math.exp
+
+object VowpalWabbitClassifier extends DefaultParamsReadable[VowpalWabbitClassifier]
+
+class VowpalWabbitClassifier(override val uid: String)
+  extends ProbabilisticClassifier[Row, VowpalWabbitClassifier, VowpalWabbitClassificationModel]
+  with VowpalWabbitBase
+{
+  def this() = this(Identifiable.randomUID("VowpalWabbitClassifier"))
+
+  override protected def train(dataset: Dataset[_]): VowpalWabbitClassificationModel = {
+
+    val binaryModel = trainInternal(dataset)
+
+    new VowpalWabbitClassificationModel(uid)
+      .setModel(binaryModel)
+      .setFeaturesCol(getFeaturesCol)
+      .setAdditionalFeatures(getAdditionalFeatures)
+      .setPredictionCol(getPredictionCol)
+      .setProbabilityCol(getProbabilityCol)
+      .setRawPredictionCol(getRawPredictionCol)
+  }
+
+  override def copy(extra: ParamMap): VowpalWabbitClassifier = defaultCopy(extra)
+}
+
+// Preparation for multi-class learning, though it no fun as numClasses is spread around multiple reductions
+class VowpalWabbitClassificationModel(override val uid: String)
+  extends ProbabilisticClassificationModel[Row, VowpalWabbitClassificationModel]
+    with VowpalWabbitBaseModel {
+
+  def numClasses: Int = 2
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val df = transformImplInternal(dataset)
+
+    // which mode one wants to use depends a bit on how this should be deployed
+    // 1. if you stay in spark w/o link=logistic is probably more convenient as it also returns the raw prediction
+    // 2. if you want to export the model *and* get probabilities at scoring term w/ link=logistic is preferable
+
+    // convert raw prediction to probability (if needed)
+    val probabilityUdf = if (vwArgs.getArgs.contains("--link=logistic"))
+      udf { (pred: Double) => Vectors.dense(Array(1 - pred, pred)) }
+    else
+      udf { (pred: Double) => {
+        val prob = 1.0 / (1.0 + exp(-pred))
+        Vectors.dense(Array(1 - prob, prob))
+      } }
+
+    val df2 = df.withColumn($(probabilityCol), probabilityUdf(col($(rawPredictionCol))))
+
+    // convert probability to prediction
+    val probability2predictionUdf = udf(probability2prediction _)
+    df2.withColumn($(predictionCol), probability2predictionUdf(col($(probabilityCol))))
+  }
+
+  override def copy(extra: ParamMap): this.type = defaultCopy(extra)
+
+  protected override def predictRaw(features: Row): Vector = {
+    throw new NotImplementedError("Not implemented")
+  }
+
+  protected override def raw2probabilityInPlace(rawPrediction: Vector): Vector= {
+    throw new NotImplementedError("Not implemented")
+  }
+}
+
+object VowpalWabbitClassificationModel extends ComplexParamsReadable[VowpalWabbitClassificationModel]

--- a/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitFeaturizer.scala
@@ -1,0 +1,141 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.contracts.{HasInputCols, HasOutputCol, Wrappable}
+import com.microsoft.ml.spark.vw.featurizer._
+import org.apache.spark.ml.{ComplexParamsReadable, ComplexParamsWritable, Transformer}
+import org.apache.spark.ml.param.{IntParam, ParamMap, StringArrayParam}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.functions.{col, struct, udf}
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+
+import scala.collection.mutable.ArrayBuilder
+
+object VowpalWabbitFeaturizer extends ComplexParamsReadable[VowpalWabbitFeaturizer]
+
+class VowpalWabbitFeaturizer(override val uid: String) extends Transformer
+  with HasInputCols with HasOutputCol with HasNumBits with Wrappable with ComplexParamsWritable
+{
+  def this() = this(Identifiable.randomUID("VowpalWabbitFeaturizer"))
+
+  setDefault(inputCols -> Array())
+
+  val seed = new IntParam(this, "seed", "Hash seed")
+  setDefault(seed -> 0)
+
+  def getSeed: Int = $(seed)
+  def setSeed(value: Int): this.type = set(seed, value)
+
+  val stringSplitInputCols = new StringArrayParam(this, "stringSplitInputCols",
+    "Input cols that should be split at word boundaries")
+  setDefault(stringSplitInputCols -> Array())
+
+  def getStringSplitInputCols: Array[String] = $(stringSplitInputCols)
+  def setStringSplitInputCols(value: Array[String]): this.type = set(stringSplitInputCols, value)
+
+  private def getAllInputCols = getInputCols ++ getStringSplitInputCols
+
+  private def getFeaturizer(name: String, dataType: DataType, idx: Int, namespaceHash: Int): Featurizer = {
+    val stringSplitInputCols = getStringSplitInputCols
+
+    dataType match {
+      case DoubleType => new NumericFeaturizer(idx, name, namespaceHash, getMask, r => r.getDouble(idx))
+      case FloatType => new NumericFeaturizer(idx, name, namespaceHash, getMask, r => r.getFloat(idx).toDouble)
+      case IntegerType => new NumericFeaturizer(idx, name, namespaceHash, getMask, r => r.getInt(idx).toDouble)
+      case LongType => new NumericFeaturizer(idx, name, namespaceHash, getMask, r => r.getLong(idx).toDouble)
+      case ShortType => new NumericFeaturizer(idx, name, namespaceHash, getMask, r => r.getShort(idx).toDouble)
+      case ByteType => new NumericFeaturizer(idx, name, namespaceHash, getMask, r => r.getByte(idx).toDouble)
+      case BooleanType => new BooleanFeaturizer(idx, name, namespaceHash, getMask)
+      case StringType =>
+        if (stringSplitInputCols.contains(name))
+          new StringSplitFeaturizer(idx, name, namespaceHash, getMask)
+      else new StringFeaturizer(idx, name, namespaceHash, getMask)
+      case arr: ArrayType => {
+        if (arr.elementType != DataTypes.StringType)
+          throw new RuntimeException(s"Unsupported array element type: ${dataType}")
+
+        new StringArrayFeaturizer(idx, name, namespaceHash, getMask)
+      }
+      case m: MapType => {
+        if (m.keyType != DataTypes.StringType)
+          throw new RuntimeException(s"Unsupported map key type: ${dataType}")
+
+        m.valueType match {
+          case StringType => new MapStringFeaturizer(idx, name, namespaceHash, getMask)
+          case DoubleType => new MapFeaturizer[Double](idx, name, namespaceHash, getMask, v => v)
+          case FloatType => new MapFeaturizer[Float](idx, name, namespaceHash, getMask, v => v.toDouble)
+          case IntegerType => new MapFeaturizer[Int](idx, name, namespaceHash, getMask, v => v.toDouble)
+          case LongType => new MapFeaturizer[Long](idx, name, namespaceHash, getMask, v => v.toDouble)
+          case ShortType => new MapFeaturizer[Short](idx, name, namespaceHash, getMask, v => v.toDouble)
+          case ByteType => new MapFeaturizer[Byte](idx, name, namespaceHash, getMask, v => v.toDouble)
+          case _ => throw new RuntimeException(s"Unsupported map value type: ${dataType}")
+        }
+      }
+      case m: Any =>
+        if (m == VectorType) // unfortunately the type is private
+          new VectorFeaturizer(idx, getMask)
+        else
+          throw new RuntimeException(s"Unsupported data type: ${dataType}")
+    }
+  }
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val inputColsList = getAllInputCols
+    val namespaceHash: Int = VowpalWabbitMurmur.hash(this.getOutputCol, this.getSeed)
+
+    val fieldSubset = dataset.schema.fields
+      .filter(f => inputColsList.contains(f.name))
+
+    val featurizers: Array[Featurizer] = fieldSubset.zipWithIndex
+      .map { case (field, idx) => getFeaturizer(field.name, field.dataType, idx, namespaceHash) }
+
+        // TODO: list types
+        // BinaryType
+        // CalendarIntervalType
+        // DateType
+        // NullType
+        // TimestampType
+        // getStruct
+
+    val mode = udf((r: Row) => {
+      val indices = ArrayBuilder.make[Int]
+      val values = ArrayBuilder.make[Double]
+
+      // educated guess on size
+      indices.sizeHint(featurizers.length)
+      values.sizeHint(featurizers.length)
+
+      // apply all featurizers
+      for (f <- featurizers)
+        if (!r.isNullAt(f.fieldIdx))
+          f.featurize(r, indices, values)
+
+      // sort by indices and remove duplicate values
+      // Warning:
+      //   - due to SparseVector limitations (which doesn't allow duplicates) we need filter
+      //   - VW command line allows for duplicate features with different values (just updates twice)
+      val (indicesSorted, valuesSorted) = VectorUtils.sortAndDistinct(indices.result, values.result, getSumCollisions)
+
+      Vectors.sparse(1 << getNumBits, indicesSorted, valuesSorted)
+    })
+
+    dataset.toDF.withColumn(getOutputCol, mode.apply(struct(fieldSubset.map(f => col(f.name)): _*)))
+  }
+
+  override def copy(extra: ParamMap): VowpalWabbitFeaturizer = defaultCopy(extra)
+
+  override def transformSchema(schema: StructType): StructType = {
+    val fieldNames = schema.fields.map(_.name)
+    for (f <- getAllInputCols)
+      if (!fieldNames.contains(f))
+        throw new IllegalArgumentException(s"missing input column $f")
+
+    schema.add(new StructField(getOutputCol, VectorType, true))
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitInteractions.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitInteractions.scala
@@ -1,0 +1,90 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.contracts.{HasInputCols, HasOutputCol, Wrappable}
+import org.apache.spark.ml.{ComplexParamsReadable, ComplexParamsWritable, Transformer}
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.functions.{col, struct, udf}
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+
+object VowpalWabbitInteractions extends ComplexParamsReadable[VowpalWabbitInteractions]
+
+/**
+  * This transformer is not intended to be used with VW classifier or regressor, but rather to bring
+  * sparse interaction concept to other SparkML learners (e.g. LR).
+  */
+class VowpalWabbitInteractions(override val uid: String) extends Transformer
+  with HasInputCols with HasOutputCol with HasNumBits with Wrappable with ComplexParamsWritable
+{
+  def this() = this(Identifiable.randomUID("VowpalWabbitInteractions"))
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val fieldSubset = dataset.schema.fields
+      .filter(f => getInputCols.contains(f.name))
+
+    val mask = getMask
+
+    val mode = udf((r: Row) => {
+
+      // compute the final number of features
+      val numElems = (0 until r.length)
+        .map(r.getAs[Vector](_).numNonzeros)
+        .fold(1)(_ * _)
+
+      val newIndices = new Array[Int](numElems)
+      val newValues = new Array[Double](numElems)
+
+      // build interaction features using FNV-1
+      val fnvPrime = 16777619
+      var i = 0
+
+      def interact(idx: Int, value: Double, ns: Int): Unit = {
+        if (ns == r.size) {
+          newIndices(i) += mask & idx
+          newValues(i) += value
+
+          i += 1
+        }
+        else {
+          val idx1 = idx * fnvPrime
+
+          r.getAs[Vector](ns).foreachActive { case (idx2, value2) =>
+            interact(idx1 ^ idx2, value * value2, ns + 1)
+          }
+        }
+      }
+
+      // start the recursion
+      interact(0, 1, 0)
+
+      val (indicesSorted, valuesSorted) = VectorUtils.sortAndDistinct(newIndices, newValues, getSumCollisions)
+
+      Vectors.sparse(1 << getNumBits, indicesSorted, valuesSorted)
+    })
+
+    dataset.toDF.withColumn(getOutputCol, mode.apply(struct(fieldSubset.map(f => col(f.name)): _*)))
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    val fieldNames = schema.fields.map(_.name)
+    for (f <- getInputCols)
+      if (!fieldNames.contains(f))
+        throw new IllegalArgumentException("missing input column " + f)
+      else {
+        val fieldType = schema.fields(schema.fieldIndex(f)).dataType
+
+        if (fieldType != VectorType)
+          throw new IllegalArgumentException("column " + f + " must be of type Vector but is " + fieldType.typeName)
+      }
+
+    schema.add(new StructField(getOutputCol, VectorType, true))
+  }
+
+  override def copy(extra: ParamMap): VowpalWabbitFeaturizer = defaultCopy(extra)
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitMurmurWithPrefix.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitMurmurWithPrefix.scala
@@ -1,0 +1,77 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+import java.nio.charset.StandardCharsets
+
+/**
+  * VW style murmur hash with pre-hashing of an initially specified prefix.
+  * @param prefix the prefix for each hashed value.
+  * @param maxSize maximum size of the string to be hashed.
+  */
+class VowpalWabbitMurmurWithPrefix(val prefix: String, val maxSize: Int = 2 * 1024) extends Serializable {
+  // worst case is 4 bytes per character
+  val ys: Array[Byte] = new Array(maxSize * 4)
+
+  val ysStart = {
+      // pre-populate the string with the prefix - we could go so-far as keep the intermediate hash state :)
+      val prefixBytes = prefix.getBytes(StandardCharsets.UTF_8)
+      Array.copy(prefixBytes, 0, ys, 0, prefixBytes.length)
+
+      prefixBytes.length
+    }
+
+  def hash(str: String, namespaceHash: Int): Int =
+    hash(str, 0, str.length, namespaceHash)
+
+  def hash(str: String, start: Int, end: Int, namespaceHash: Int): Int = {
+    if (end - start > maxSize)
+      VowpalWabbitMurmur.hash(prefix + str.substring(start, end), namespaceHash)
+    else {
+      // adapted from https://stackoverflow.com/questions/5513144/converting-char-to-byte/20604909#20604909
+      // copy sub part
+      var i = start
+      var j = ysStart // i for chars; j for bytes
+      while (i < end) { // fill ys with bytes
+        val c = str.charAt(i)
+        if (c < 0x80) {
+          ys(j) = c.toByte
+          i = i + 1
+          j = j + 1
+        } else if (c < 0x800) {
+          ys(j) = (0xc0 | (c >> 6)).toByte
+          ys(j + 1) = (0x80 | (c & 0x3f)).toByte
+          i = i + 1
+          j = j + 2
+        } else if (Character.isHighSurrogate(c)) {
+          if (end - i < 2) throw new Exception("overflow") // this is not reachable due to maxSize * 4, so just in case
+          val d = str.charAt(i + 1)
+          val uc: Int =
+            if (Character.isLowSurrogate(d))
+              Character.toCodePoint(c, d)
+            else
+              throw new Exception("malformed")
+
+          ys(j) = (0xf0 | ((uc >> 18))).toByte
+          ys(j + 1) = (0x80 | ((uc >> 12) & 0x3f)).toByte
+          ys(j + 2) = (0x80 | ((uc >> 6) & 0x3f)).toByte
+          ys(j + 3) = (0x80 | (uc & 0x3f)).toByte
+          i = i + 2 // 2 chars
+          j = j + 4
+        } else if (Character.isLowSurrogate(c)) {
+          throw new Exception("malformed")
+        } else {
+          ys(j) = (0xe0 | (c >> 12)).toByte
+          ys(j + 1) = (0x80 | ((c >> 6) & 0x3f)).toByte
+          ys(j + 2) = (0x80 | (c & 0x3f)).toByte
+          i = i + 1
+          j = j + 3
+        }
+      }
+
+      VowpalWabbitMurmur.hash(ys, 0, j, namespaceHash)
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitRegressor.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/VowpalWabbitRegressor.scala
@@ -1,0 +1,53 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.env.InternalWrapper
+import com.microsoft.ml.spark.core.serialize.ConstructorReadable
+import org.apache.spark.ml.{BaseRegressor, ComplexParamsReadable, ComplexParamsWritable}
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.util._
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.col
+import org.apache.spark.ml.regression.RegressionModel
+
+object VowpalWabbitRegressor extends DefaultParamsReadable[VowpalWabbitRegressor]
+
+class VowpalWabbitRegressor(override val uid: String)
+  extends BaseRegressor[Row, VowpalWabbitRegressor, VowpalWabbitRegressorModel]
+    with VowpalWabbitBase
+{
+  def this() = this(Identifiable.randomUID("VowpalWabbitRegressor"))
+
+  override def train(dataset: Dataset[_]): VowpalWabbitRegressorModel = {
+    val binaryModel = trainInternal(dataset)
+
+    new VowpalWabbitRegressorModel(uid)
+      .setModel(binaryModel)
+      .setFeaturesCol(getFeaturesCol)
+      .setAdditionalFeatures(getAdditionalFeatures)
+      .setPredictionCol(getPredictionCol)
+  }
+
+  override def copy(extra: ParamMap): VowpalWabbitRegressor = defaultCopy(extra)
+}
+
+class VowpalWabbitRegressorModel(override val uid: String)
+  extends RegressionModel[Row, VowpalWabbitRegressorModel]
+    with VowpalWabbitBaseModel
+    with ComplexParamsWritable
+{
+  protected override def transformImpl(dataset: Dataset[_]): DataFrame = {
+    transformImplInternal(dataset)
+      .withColumn($(predictionCol), col($(rawPredictionCol)))
+  }
+
+  override def predict(features: Row): Double = {
+    throw new NotImplementedError("Not implement")
+  }
+
+  override def copy(extra: ParamMap): this.type = defaultCopy(extra)
+}
+
+object VowpalWabbitRegressorModel extends ComplexParamsReadable[VowpalWabbitRegressorModel]

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/BooleanFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/BooleanFeaturizer.scala
@@ -1,0 +1,43 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import org.apache.spark.sql.Row
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+
+import scala.collection.mutable.{ArrayBuilder}
+
+/**
+  * Featurize boolean value into native VW structure. (True = hash(feature name):1, False ignored).
+  * @param fieldIdx input field index.
+  * @param columnName used as feature name.
+  * @param namespaceHash pre-hashed namespace.
+  * @param mask bit mask applied to final hash.
+  */
+class BooleanFeaturizer(override val fieldIdx: Int, columnName: String, namespaceHash: Int, mask: Int)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * Pre-hashed feature index.
+    */
+  val featureIdx = mask & VowpalWabbitMurmur.hash(columnName, namespaceHash)
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+    if (row.getBoolean(fieldIdx)) {
+        indices += featureIdx
+        values += 1.0
+    }
+
+    ()
+  }
+}
+

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/Featurizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/Featurizer.scala
@@ -1,0 +1,21 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import org.apache.spark.sql.Row
+
+import scala.collection.mutable.ArrayBuilder
+
+abstract class Featurizer(val fieldIdx: Int) extends Serializable {
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/MapFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/MapFeaturizer.scala
@@ -1,0 +1,44 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import org.apache.spark.sql.Row
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+
+import scala.collection.mutable.{ArrayBuilder}
+
+/**
+  * Featurize map of type T into native VW structure. (hash(column name + k):value)
+  * @param fieldIdx input field index.
+  * @param columnName used as feature name prefix.
+  * @param namespaceHash pre-hashed namespace.
+  * @param mask bit mask applied to final hash.
+  * @param valueFeaturizer featurizer for value type.
+  * @tparam T value type.
+  */
+class MapFeaturizer[T](override val fieldIdx: Int, val columnName: String, val namespaceHash: Int,
+                       val mask: Int, val valueFeaturizer: (T) => Double)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+    for ((k,v) <- row.getMap[String, T](fieldIdx).iterator) {
+      val value = valueFeaturizer(v)
+
+      // Note: 0 valued features are always filtered.
+      if (value != 0) {
+        indices += mask & VowpalWabbitMurmur.hash(columnName + k, namespaceHash)
+        values += value
+      }
+    }
+  }
+}
+

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/MapStringFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/MapStringFeaturizer.scala
@@ -1,0 +1,41 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import com.microsoft.ml.spark.vw.VowpalWabbitMurmurWithPrefix
+import org.apache.spark.sql.Row
+
+import scala.collection.mutable.ArrayBuilder
+
+/**
+  * Featurize map strings into native VW structure. (hash(column name + k + v):1)
+  * @param fieldIdx input field index.
+  * @param columnName ignored.
+  * @param namespaceHash pre-hashed namespace.
+  * @param mask bit mask applied to final hash.
+  */
+class MapStringFeaturizer(override val fieldIdx: Int, val columnName: String, namespaceHash: Int, val mask: Int)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * Initialize hasher that already pre-hashes the column prefix.
+    */
+  val hasher = new VowpalWabbitMurmurWithPrefix(columnName)
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+    for ((k,v) <- row.getMap[String, String](fieldIdx).iterator) {
+      indices += mask & hasher.hash(k + v, namespaceHash)
+      values += 1.0
+    }
+  }
+}
+

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/NumericFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/NumericFeaturizer.scala
@@ -1,0 +1,46 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import org.apache.spark.sql.Row
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+
+import scala.collection.mutable.ArrayBuilder
+
+/**
+  * Featurize numeric values into native VW structure. ((hash(column name):value)
+  * @param fieldIdx input field index.
+  * @param columnName used as feature name prefix.
+  * @param namespaceHash pre-hashed namespace.
+  * @param mask bit mask applied to final hash.
+  * @param getFieldValue lambda to unify the cast/conversion to double.
+  */
+class NumericFeaturizer(override val fieldIdx: Int, columnName: String, namespaceHash: Int,
+                        mask: Int, val getFieldValue: (Row) => Double)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * Pre-hashed feature index.
+    */
+  val featureIdx = mask & VowpalWabbitMurmur.hash(columnName, namespaceHash)
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+    val value = getFieldValue(row)
+
+    // Note: 0 valued features are always filtered.
+    if (value != 0) {
+        indices += featureIdx
+        values += value
+    }
+    ()
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/StringArrayFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/StringArrayFeaturizer.scala
@@ -1,0 +1,41 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import com.microsoft.ml.spark.vw.VowpalWabbitMurmurWithPrefix
+import org.apache.spark.sql.Row
+
+import scala.collection.mutable.ArrayBuilder
+
+/**
+  * Featurize array of strings into native VW structure. (hash(column name + k):1)
+  * @param fieldIdx input field index.
+  * @param columnName used as feature name prefix.
+  * @param namespaceHash pre-hashed namespace.
+  * @param mask bit mask applied to final hash.
+  */
+class StringArrayFeaturizer(override val fieldIdx: Int, val columnName: String, val namespaceHash: Int, val mask: Int)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * Initialize hasher that already pre-hashes the column prefix.
+    */
+  val hasher = new VowpalWabbitMurmurWithPrefix(columnName)
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+    for (s <- row.getSeq[String](fieldIdx)) {
+      indices += mask & hasher.hash(s, namespaceHash)
+      values += 1.0
+    }
+  }
+}
+

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/StringFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/StringFeaturizer.scala
@@ -1,0 +1,40 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import com.microsoft.ml.spark.vw.VowpalWabbitMurmurWithPrefix
+import org.apache.spark.sql.Row
+
+import scala.collection.mutable.ArrayBuilder
+
+/**
+  * Featurize string into native VW structure. (hash(column name + value):1)
+  * @param fieldIdx input field index.
+  * @param columnName used as feature name prefix.
+  * @param namespaceHash pre-hashed namespace.
+  * @param mask bit mask applied to final hash.
+  */
+class StringFeaturizer(override val fieldIdx: Int, val columnName: String, val namespaceHash: Int, val mask: Int)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * Pre-hashed feature index.
+    */
+  val hasher = new VowpalWabbitMurmurWithPrefix(columnName)
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+    indices += mask & hasher.hash(row.getString(fieldIdx), namespaceHash)
+    values += 1.0
+
+    ()
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/StringSplitFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/StringSplitFeaturizer.scala
@@ -1,0 +1,56 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import com.microsoft.ml.spark.vw.VowpalWabbitMurmurWithPrefix
+import org.apache.spark.sql.Row
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+
+import scala.collection.mutable.ArrayBuilder
+
+/**
+  * Featurize strings by splitting into native VW structure. (hash(s(0)):value, hash(s(1)):value, ...)
+  * @param fieldIdx input field index.
+  * @param columnName used as feature name prefix.
+  * @param namespaceHash pre-hashed namespace.
+  * @param mask bit mask applied to final hash.
+  */
+class StringSplitFeaturizer(override val fieldIdx: Int, val columnName: String, val namespaceHash: Int, val mask: Int)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * (?U) makes \w unicode aware
+    * https://stackoverflow.com/questions/4304928/unicode-equivalents-for-w-and-b-in-java-regular-expressions
+    * we could follow
+    * https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html
+    * but that strips single character words...
+    *
+    * TODO: expose as user configurable parameter
+    */
+  val nonWhiteSpaces = "(?U)\\w+".r
+
+  /**
+    * Initialize hasher that already pre-hashes the column prefix.
+    */
+  val hasher = new VowpalWabbitMurmurWithPrefix(columnName)
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+    val s = row.getString(fieldIdx)
+
+    for (e <- nonWhiteSpaces.findAllMatchIn(s)) {
+      // Note: since the hasher access the chars directly. this avoids allocation.
+      indices +=  mask & hasher.hash(s, e.start, e.end, namespaceHash)
+
+      values += 1.0
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/vw/featurizer/VectorFeaturizer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/vw/featurizer/VectorFeaturizer.scala
@@ -1,0 +1,52 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw.featurizer
+
+import org.apache.spark.sql.Row
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector}
+
+import scala.collection.mutable.ArrayBuilder
+
+/**
+  * Featurize sparse and dense vector into native VW structure. (hash(s(0)):value, hash(s(1)):value, ...)
+  * @param fieldIdx input field index.
+  * @param mask bit mask applied to final hash.
+  */
+class VectorFeaturizer(override val fieldIdx: Int, val mask: Int)
+  extends Featurizer(fieldIdx) {
+
+  /**
+    * Featurize a single row.
+    * @param row input row.
+    * @param indices output indices.
+    * @param values output values.
+    * @note this interface isn't very Scala-esce, but it avoids lots of allocation.
+    *       Also due to SparseVector limitations we don't support 64bit indices (e.g. indices are signed 32bit ints)
+    */
+  override def featurize(row: Row, indices: ArrayBuilder[Int], values: ArrayBuilder[Double]): Unit = {
+
+    row.getAs[Vector](fieldIdx) match {
+      case v: DenseVector => {
+        // check if we need to hash
+        if (v.size < mask + 1)
+          indices ++= 0 until v.size
+        else
+          indices ++= (0 until v.size).map { mask & _ }
+
+        values ++= v.values
+      }
+      case v: SparseVector => {
+        // check if we need to hash
+        if (v.size < mask + 1)
+          indices ++= v.indices
+        else
+          indices ++= v.indices.map { mask & _ }
+
+        values ++= v.values
+      }
+    }
+
+    ()
+  }
+}

--- a/src/test/resources/benchmarks/benchmarks_VerifyVowpalWabbitRegressor.csv
+++ b/src/test/resources/benchmarks/benchmarks_VerifyVowpalWabbitRegressor.csv
@@ -1,0 +1,16 @@
+name,value,precision,higherIsBetter
+VowpalWabbitRegressor_energyefficiency2012_data.train.csv_,8.137509233528203,1.0,false
+VowpalWabbitRegressor_energyefficiency2012_data.train.csv_--bfgs,24.48041415526995,1.0,false
+VowpalWabbitRegressor_energyefficiency2012_data.train.csv_--adaptive,12.960062725747207,1.0,false
+VowpalWabbitRegressor_airfoil_self_noise.train.csv_,70.43269163082503,0.1,false
+VowpalWabbitRegressor_airfoil_self_noise.train.csv_--bfgs,125.02628687166887,0.1,false
+VowpalWabbitRegressor_airfoil_self_noise.train.csv_--adaptive,17.476643558307703,0.1,false
+VowpalWabbitRegressor_Buzz.TomsHardware.train.csv_,13293.0085777787,1000.0,false
+VowpalWabbitRegressor_Buzz.TomsHardware.train.csv_--bfgs,13352.911513304409,1000.0,false
+VowpalWabbitRegressor_Buzz.TomsHardware.train.csv_--adaptive,4064.9979055539925,1000.0,false
+VowpalWabbitRegressor_machine.train.csv_,178.66842858742254,100.0,false
+VowpalWabbitRegressor_machine.train.csv_--bfgs,183.5800804363435,100.0,false
+VowpalWabbitRegressor_machine.train.csv_--adaptive,183.5800804363435,100.0,false
+VowpalWabbitRegressor_Concrete_Data.train.csv_,15.735532284668981,1.0,false
+VowpalWabbitRegressor_Concrete_Data.train.csv_--bfgs,39.51882087437542,1.0,false
+VowpalWabbitRegressor_Concrete_Data.train.csv_--adaptive,39.51882087437542,1.0,false

--- a/src/test/scala/com/microsoft/ml/spark/core/test/benchmarks/Benchmarks.scala
+++ b/src/test/scala/com/microsoft/ml/spark/core/test/benchmarks/Benchmarks.scala
@@ -34,7 +34,7 @@ object Benchmark {
 }
 
 abstract class Benchmarks extends TestBase {
-  val moduleName: String
+
   lazy val resourcesDirectory = new File(getClass.getResource("/").toURI)
   lazy val oldBenchmarkFile = new File(new File(resourcesDirectory, "benchmarks"), s"benchmarks_${this}.csv")
   lazy val newBenchmarkFile = new File(new File(resourcesDirectory, "new_benchmarks"), s"new_benchmarks_${this}.csv")
@@ -93,9 +93,6 @@ abstract class Benchmarks extends TestBase {
   }
 
   def verifyBenchmarks(): Unit = {
-    import session.implicits._
-    val newBenchmarkDF = newBenchmarks.toDF()
-
     if (newBenchmarkFile.exists()) newBenchmarkFile.delete()
     writeCSV(newBenchmarks, newBenchmarkFile)
 

--- a/src/test/scala/com/microsoft/ml/spark/core/test/fuzzing/FuzzingTest.scala
+++ b/src/test/scala/com/microsoft/ml/spark/core/test/fuzzing/FuzzingTest.scala
@@ -169,6 +169,8 @@ class FuzzingTest extends TestBase {
 
     val exemptions = Set[String](
       "org.apache.spark.ml.feature.FastVectorAssembler", // In Spark namespace
+      "com.microsoft.ml.spark.vw.VowpalWabbitClassifier", // HasFeaturesCol is part of spark's base class
+      "com.microsoft.ml.spark.vw.VowpalWabbitRegressor", // HasFeaturesCol is part of spark's base class
       "com.microsoft.ml.spark.lightgbm.LightGBMClassifier", // HasFeaturesCol is part of spark's base class
       "com.microsoft.ml.spark.lightgbm.LightGBMRegressor", // HasFeaturesCol is part of spark's base class
       "com.microsoft.ml.spark.lightgbm.LightGBMRanker" // HasFeaturesCol is part of spark's base class

--- a/src/test/scala/com/microsoft/ml/spark/core/utils/JarLoadingUtils.scala
+++ b/src/test/scala/com/microsoft/ml/spark/core/utils/JarLoadingUtils.scala
@@ -3,8 +3,6 @@
 
 package com.microsoft.ml.spark.core.utils
 
-import java.io.{InputStream, ObjectInputStream, ObjectStreamClass}
-
 import org.scalatest.exceptions.TestFailedException
 import org.spark_project.guava.reflect.ClassPath
 
@@ -101,12 +99,3 @@ object JarLoadingUtils {
 
 }
 
-class ContextObjectInputStream(input: InputStream) extends ObjectInputStream(input) {
-  protected override def resolveClass(desc: ObjectStreamClass): Class[_] = {
-    try {
-      Class.forName(desc.getName, false, Thread.currentThread().getContextClassLoader)
-    } catch {
-      case _: ClassNotFoundException => super.resolveClass(desc)
-    }
-  }
-}

--- a/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitClassifier.scala
+++ b/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitClassifier.scala
@@ -1,0 +1,160 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.test.benchmarks.{Benchmarks, DatasetUtils}
+import org.apache.spark.ml.evaluation.BinaryClassificationEvaluator
+import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.sql.DataFrame
+import com.microsoft.ml.spark.core.test.fuzzing.{EstimatorFuzzing, TestObject}
+import org.apache.spark.TaskContext
+import org.apache.spark.ml.tuning.{CrossValidator, ParamGridBuilder}
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+
+class VerifyVowpalWabbitClassifier extends Benchmarks with EstimatorFuzzing[VowpalWabbitClassifier] {
+  lazy val moduleName = "vw"
+  val numPartitions = 2
+
+  test("Verify VowpalWabbit Classifier can be run with TrainValidationSplit") {
+      val fileName = "a1a.train.svmlight"
+
+      val fileLocation = DatasetUtils.binaryTrainFile(fileName).toString
+      val dataset = session.read.format("libsvm").load(fileLocation).repartition(numPartitions)
+
+    val vw = new VowpalWabbitClassifier()
+        .setArgs("--link=logistic --quiet")
+
+    val paramGrid = new ParamGridBuilder()
+       .addGrid(vw.learningRate, Array(0.5, 0.05, 0.001))
+       .addGrid(vw.numPasses, Array(1, 3, 5))
+       .build()
+
+    val cv = new CrossValidator()
+      .setEstimator(vw)
+      .setEvaluator(new BinaryClassificationEvaluator)
+      .setEstimatorParamMaps(paramGrid)
+      .setNumFolds(3)
+      .setParallelism(2) // thanks to dynamic port assignment in spanning_tree.cc :)
+
+    val model = cv.fit(dataset)
+    model.transform(dataset)
+
+    val auc = model.avgMetrics(0)
+    println(s"areaUnderROC: $auc")
+  }
+
+  test("Verify VowpalWabbit Classifier can be run with libsvm") {
+    val fileName = "a1a.train.svmlight"
+
+    val fileLocation = DatasetUtils.binaryTrainFile(fileName).toString
+    val dataset = session.read.format("libsvm").load(fileLocation).repartition(numPartitions)
+
+    val vw = new VowpalWabbitClassifier()
+      .setPowerT(0.3)
+      .setNumPasses(3)
+
+    val classifier = vw.fit(dataset)
+    assert(classifier.getModel.length > 400)
+
+    val labelOneCnt = classifier.transform(dataset).select("prediction").filter(_.getDouble(0) == 1.0).count()
+
+    assert(labelOneCnt < dataset.count)
+    assert(labelOneCnt > 10)
+  }
+
+  test("Verify VowpalWabbit Classifier can deal with empty partitions") {
+    val fileName = "a1a.train.svmlight"
+
+    val fileLocation = DatasetUtils.binaryTrainFile(fileName).toString
+    val dataset = session.read.format("libsvm").load(fileLocation).repartition(4)
+
+    val vw = new VowpalWabbitClassifier()
+      .setPowerT(0.3)
+      .setNumPasses(3)
+
+    val infoEnc = RowEncoder(dataset.schema)
+    val trainData = dataset
+      .mapPartitions(iter => {
+        val ctx = TaskContext.get
+        val partId = ctx.partitionId
+        // Create an empty partition
+        if (partId == 0) {
+          Iterator()
+        } else {
+          iter
+        }
+      })(infoEnc)
+
+    val classifier = vw.fit(trainData)
+    assert(classifier.getModel.length > 400)
+  }
+
+  test("Verify VowpalWabbit Classifier w/ and w/o link=logistic produce same results") {
+    val fileName = "a1a.train.svmlight"
+    val labelColumnName = "Diabetes mellitus"
+
+    val fileLocation = DatasetUtils.binaryTrainFile(fileName).toString
+    val dataset = session.read.format("libsvm").load(fileLocation).repartition(numPartitions)
+
+    // https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Predicting-probabilities
+    val vw1 = new VowpalWabbitClassifier()
+        .setNumPasses(2)
+    val classifier1 = vw1.fit(dataset)
+
+    val vw2 = new VowpalWabbitClassifier()
+        .setArgs("--link=logistic")
+        .setNumPasses(2)
+    val classifier2 = vw1.fit(dataset)
+
+    val labelOneCnt1 = classifier1.transform(dataset).select("prediction").filter(_.getDouble(0) == 1.0).count()
+    val labelOneCnt2 = classifier2.transform(dataset).select("prediction").filter(_.getDouble(0) == 1.0).count()
+
+    assert(labelOneCnt1 == labelOneCnt2)
+  }
+
+  test("Verify VowpalWabbit Classifier w/ bfgs and cache file") {
+    val fileName = "a1a.train.svmlight"
+    val labelColumnName = "Diabetes mellitus"
+
+    val fileLocation = DatasetUtils.binaryTrainFile(fileName).toString
+    val dataset = session.read.format("libsvm").load(fileLocation).repartition(numPartitions)
+
+    val vw1 = new VowpalWabbitClassifier()
+      .setNumPasses(3)
+      .setArgs("--loss_function=logistic --bfgs")
+    val classifier1 = vw1.fit(dataset)
+
+    val labelOneCnt1 = classifier1.transform(dataset).select("prediction").filter(_.getDouble(0) == 1.0).count()
+
+    println(labelOneCnt1)
+  }
+
+  /** Reads a CSV file given the file name and file location.
+    * @param fileName The name of the csv file.
+    * @param fileLocation The full path to the csv file.
+    * @return A dataframe from read CSV file.
+    */
+  def readCSV(fileName: String, fileLocation: String): DataFrame = {
+    session.read
+      .option("header", "true").option("inferSchema", "true")
+      .option("treatEmptyValuesAsNulls", "false")
+      .option("delimiter", if (fileName.endsWith(".csv")) "," else "\t")
+      .csv(fileLocation)
+  }
+
+  override def reader: MLReadable[_] = VowpalWabbitClassifier
+  override def modelReader: MLReadable[_] = VowpalWabbitClassificationModel
+
+  override def testObjects(): Seq[TestObject[VowpalWabbitClassifier]] = {
+
+    val fileName = "a1a.train.svmlight"
+
+    val fileLocation = DatasetUtils.binaryTrainFile(fileName).toString
+    val dataset = session.read.format("libsvm").load(fileLocation).repartition(numPartitions)
+
+    Seq(new TestObject(
+      new VowpalWabbitClassifier(),
+      dataset))
+  }
+}

--- a/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitFeaturizer.scala
+++ b/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitFeaturizer.scala
@@ -1,0 +1,250 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.test.base.TestBase
+import com.microsoft.ml.spark.core.test.fuzzing.{TestObject, TransformerFuzzing}
+import org.apache.spark.ml.linalg.{SparseVector, Vector, Vectors}
+import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+
+import scala.reflect.runtime.universe.TypeTag
+
+class VerifyVowpalWabbitFeaturizer extends TestBase with TransformerFuzzing[VowpalWabbitFeaturizer] {
+
+  val defaultMask = (1 << 30) - 1
+
+  case class Sample1(str: String, seq: Seq[String])
+
+  case class Input[T](in: T)
+
+  case class Input2[T, S](in1: T, in2: S)
+
+  test("Verify VowpalWabbit Featurizer can be run with seq and string") {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("str", "seq"))
+      .setOutputCol("features")
+    val df1 = session.createDataFrame(Seq(Sample1("abc", Seq("foo", "bar"))))
+
+    val v1 = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[Vector](0)
+
+    val featurizer2 = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("seq", "str"))
+      .setOutputCol("features")
+    val df2 = session.createDataFrame(Seq(Sample1("abc", Seq("foo", "bar"))))
+
+    val v2 = featurizer2.transform(df2).select(col("features")).collect.apply(0).getAs[Vector](0)
+
+    assert(v1.equals(v2))
+  }
+
+  private def testNumeric[T: TypeTag](v: T) = {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("in"))
+      .setOutputCol("features")
+    val df1 = session.createDataFrame(Seq(Input[T](v)))
+
+    val v1 = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[SparseVector](0)
+
+    assert(v1.numNonzeros == 1)
+    assert(v1.indices(0) == VowpalWabbitMurmur.hash("in", VowpalWabbitMurmur.hash("features", 0)))
+    assert(v1.values(0) == v)
+  }
+
+  test("Verify VowpalWabbit Featurizer can be run with numeric") {
+    testNumeric[Int](5)
+    testNumeric[Short](5)
+    testNumeric[Byte](5)
+    testNumeric[Long](5)
+    testNumeric[Double](5.2)
+    testNumeric[Float](5.2f)
+  }
+
+  test("Verify VowpalWabbit Featurizer can be run with string") {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("in"))
+      .setOutputCol("features")
+    val df1 = session.createDataFrame(Seq(Input[String]("markus")))
+
+    val v1 = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[SparseVector](0)
+
+    assert(v1.numNonzeros == 1)
+    assert(v1.indices(0) == VowpalWabbitMurmur.hash("inmarkus", VowpalWabbitMurmur.hash("features", 0)))
+    assert(v1.values(0) == 1.0)
+  }
+
+  test("Verify VowpalWabbit Featurizer can be run with ArrayString") {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("in"))
+      .setOutputCol("features")
+    val df1 = session.createDataFrame(Seq(Input[Array[String]](Array("markus", "marie"))))
+
+    val v1 = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[SparseVector](0)
+
+    assert(v1.numNonzeros == 2)
+    assert(v1.indices(0) == (defaultMask &
+      VowpalWabbitMurmur.hash("inmarkus", VowpalWabbitMurmur.hash("features", 0))))
+    assert(v1.indices(1) == (defaultMask &
+      VowpalWabbitMurmur.hash("inmarie", VowpalWabbitMurmur.hash("features", 0))))
+    assert(v1.values(0) == 1.0)
+    assert(v1.values(1) == 1.0)
+  }
+
+  private def testMap[T: TypeTag](v1: T, v2: T) = {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("in"))
+      .setOutputCol("features")
+
+    val df1 = session.createDataFrame(Seq(Input[Map[String, T]](Map[String, T]("k1" -> v1, "k2" -> v2))))
+
+    val vec = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[SparseVector](0)
+
+    assert(vec.numNonzeros == 2)
+
+    // note: order depends on the hashes
+    assert(vec.indices(0) == (defaultMask &
+      VowpalWabbitMurmur.hash("ink1", VowpalWabbitMurmur.hash("features", 0))))
+    assert(vec.indices(1) == (defaultMask &
+      VowpalWabbitMurmur.hash("ink2", VowpalWabbitMurmur.hash("features", 0))))
+    assert(vec.values(0) == v1)
+    assert(vec.values(1) == v2)
+  }
+
+  test("Verify VowpalWabbit Featurizer can be run with MapStringDouble") {
+    testMap[Int](5, 4)
+    testMap[Short](5, 4)
+    testMap[Byte](5, 4)
+    testMap[Long](5, 4)
+    testMap[Double](5.2, 3.1)
+    testMap[Float](5.2f, 3.1f)
+  }
+
+  test("Verify VowpalWabbit Featurizer can be run with StringSplitString") {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setStringSplitInputCols(Array("in"))
+      .setOutputCol("features")
+    val df1 = session.createDataFrame(Seq(Input[String]("markus  marie")))
+
+    val v1 = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[SparseVector](0)
+
+    assert(v1.numNonzeros == 2)
+    assert(v1.indices(0) == (defaultMask &
+      VowpalWabbitMurmur.hash("inmarkus", VowpalWabbitMurmur.hash("features", 0))))
+    assert(v1.indices(1) == (defaultMask &
+      VowpalWabbitMurmur.hash("inmarie", VowpalWabbitMurmur.hash("features", 0))))
+    assert(v1.values(0) == 1.0)
+    assert(v1.values(1) == 1.0)
+  }
+
+  test("Verify VowpalWabbit Featurizer can generate duplicates") {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setStringSplitInputCols(Array("in"))
+      .setOutputCol("features")
+    val df1 = session.createDataFrame(Seq(Input[String]("markus markus markus")))
+
+    val v1 = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[SparseVector](0)
+
+    assert(v1.numNonzeros == 1)
+    assert(v1.indices(0) == (defaultMask &
+      VowpalWabbitMurmur.hash("inmarkus", VowpalWabbitMurmur.hash("features", 0))))
+    assert(v1.values(0) == 3.0)
+  }
+
+  test("Verify VowpalWabbit Featurizer can generate duplicates and remove") {
+    val featurizer1 = new VowpalWabbitFeaturizer()
+      .setSumCollisions(false)
+      .setStringSplitInputCols(Array("in"))
+      .setOutputCol("features")
+    val df1 = session.createDataFrame(Seq(Input[String]("markus markus")))
+
+    val v1 = featurizer1.transform(df1).select(col("features")).collect.apply(0).getAs[SparseVector](0)
+
+    assert(v1.numNonzeros == 1)
+    assert(v1.indices(0) == (defaultMask &
+      VowpalWabbitMurmur.hash("inmarkus", VowpalWabbitMurmur.hash("features", 0))))
+    assert(v1.values(0) == 1.0)
+  }
+
+  test("Verify VowpalWabbit Featurizer output VectorUDT schema type") {
+    val newSchema = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("data"))
+      .setOutputCol("features")
+      .transformSchema(new StructType(Array(new StructField("data", DataTypes.DoubleType, true))))
+
+    assert(newSchema.fields(1).name == "features")
+    assert(newSchema.fields(1).dataType.typeName == "vector")
+  }
+
+  private def verifyArrays[T](actual: Array[T], expected: Array[T])(implicit ord: Ordering[T]) = {
+    assert(actual.length == expected.length)
+
+    (actual.sorted zip expected.sorted).forall { case (x, y) => x == y }
+  }
+
+  test("Verify VowpalWabbit Featurizer can combine vectors") {
+    val df1 = session.createDataFrame(Seq(Input2[Vector, Vector](
+      Vectors.dense(1.0, 2.0, 3.0),
+      Vectors.sparse(8, Array(1, 4), Array(5.0, 8.0))
+    )))
+
+    val featurizer = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("in1", "in2"))
+      .setOutputCol("features")
+      .setNumBits(18)
+
+    val dfOut = featurizer.transform(df1)
+
+    val output = dfOut.head.getAs[SparseVector]("features")
+
+    assert(output.size == 262144)
+    assert(output.numNonzeros == 4)
+
+    verifyArrays(output.values, Array(1.0, 7.0, 3.0, 8.0))
+  }
+
+  test("Verify VowpalWabbit Featurizer can combine vectors and remask") {
+    val df1 = session.createDataFrame(Seq(Input2[Vector, Vector](
+      Vectors.dense(1.0, 2.0, 3.0),
+      Vectors.sparse(8, Array(1, 4), Array(5.0, 8.0))
+    )))
+
+    val featurizer = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("in1", "in2"))
+      .setOutputCol("features")
+      .setNumBits(2)
+
+    val dfOut = featurizer.transform(df1)
+
+    val output = dfOut.head.getAs[SparseVector]("features")
+
+    assert(output.size == 4)
+    assert(output.numNonzeros == 3)
+
+    verifyArrays(output.values, Array(9.0, 7.0, 3.0))
+  }
+
+  test("Check tamil encoding") {
+    //noinspection ScalaStyle
+    val df = session.createDataFrame(Seq(
+      ("ஜெய்-அஞ்சலி காதல் பற்றி ராய் லட்சுமி!", "output")))
+      .toDF("a", "normalized")
+
+    val featurizer = new VowpalWabbitFeaturizer()
+      .setStringSplitInputCols(Array("a"))
+      .setOutputCol("features")
+
+    val result = featurizer.transform(df)
+    val vec = result.head().getAs[SparseVector](2)
+
+    assert(vec.numNonzeros == 6)
+    verifyArrays(vec.indices, Array(260933379, 376953061, 482756394, 597851995, 781002072, 950998778))
+  }
+
+  def testObjects(): Seq[TestObject[VowpalWabbitFeaturizer]] = List(new TestObject(
+    new VowpalWabbitFeaturizer().setInputCols(Array("words")).setOutputCol("out"), makeBasicDF()))
+
+  override def reader: MLReadable[_] = VowpalWabbitFeaturizer
+}

--- a/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitInteractions.scala
+++ b/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitInteractions.scala
@@ -1,0 +1,65 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.test.base.TestBase
+import com.microsoft.ml.spark.core.test.fuzzing.{TestObject, TransformerFuzzing}
+import org.apache.spark.ml.linalg.{SparseVector, Vector, Vectors}
+import org.apache.spark.ml.util.MLReadable
+
+class VerifyVowpalWabbitInteractions extends TestBase with TransformerFuzzing[VowpalWabbitInteractions] {
+
+  case class Data(val v1: Vector, val v2: Vector, val v3: Vector)
+
+  lazy val df = session.createDataFrame(Seq(Data(
+    Vectors.dense(Array(1.0, 2.0, 3.0)),
+    Vectors.sparse(8, Array(5), Array(4.0)),
+    Vectors.sparse(11, Array(8, 9), Array(7.0, 8.0))
+  )))
+
+  private def verifyValues(actual: SparseVector, expected: Array[Double]) = {
+    assert(actual.numNonzeros == expected.length)
+
+    (actual.values.sorted zip expected.sorted).forall{ case (x,y) => x == y }
+  }
+
+  test("Verify VowpalWabbit Interactions 3-dense x 1-sparse") {
+    val interactions = new VowpalWabbitInteractions()
+      .setInputCols(Array("v1", "v2"))
+      .setOutputCol("features")
+
+    val v = interactions.transform(df).head().getAs[SparseVector]("features")
+
+    verifyValues(v, Array(4.0, 8, 12.0))
+  }
+
+  test("Verify VowpalWabbit Interactions 1-sparse x 2-sparse") {
+    val interactions = new VowpalWabbitInteractions()
+      .setInputCols(Array("v2", "v3"))
+      .setOutputCol("features")
+
+    val v = interactions.transform(df).head().getAs[SparseVector]("features")
+
+    verifyValues(v, Array(28.0, 32.0))
+  }
+
+  test("Verify VowpalWabbit Interactions 3-dense x 1-sparse x 2-sparse") {
+    val interactions = new VowpalWabbitInteractions()
+      .setInputCols(Array("v1", "v2", "v3"))
+      .setOutputCol("features")
+
+    val v = interactions.transform(df).head().getAs[SparseVector]("features")
+
+    verifyValues(v, Array(
+      1.0 * 5 * 7, 1 * 5 * 8.0,
+      2.0 * 5 * 7, 2 * 5 * 8.0,
+      3.0 * 5 * 7, 3 * 5 * 8.0
+    ))
+  }
+
+  def testObjects(): Seq[TestObject[VowpalWabbitInteractions]] = List(new TestObject(
+    new VowpalWabbitInteractions().setInputCols(Array("v1")).setOutputCol("out"), df))
+
+  override def reader: MLReadable[_] = VowpalWabbitInteractions
+}

--- a/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitMurmurWithPrefix.scala
+++ b/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitMurmurWithPrefix.scala
@@ -1,0 +1,81 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import org.vowpalwabbit.spark.VowpalWabbitMurmur
+import java.nio.charset.StandardCharsets
+
+import com.microsoft.ml.spark.core.test.base.TestBase
+
+class VerifyVowpalWabbitMurmurWithPrefix extends TestBase {
+
+  case class Sample1(val str: String, val seq: Seq[String])
+
+  test("Verify VowpalWabbitMurmurWithPrefix-based hash produces same results") {
+    val prefix = "Markus"
+
+    val fastStringHash = new VowpalWabbitMurmurWithPrefix(prefix)
+
+    var time1: Long = 0
+    var time2: Long = 0
+    var time3: Long = 0
+
+    for (j <- 0 until 1024) {
+      val sb = new StringBuilder
+
+      for (i <- 0 until 128) {
+        sb.append(i)
+
+        val str = sb.toString
+
+        // prefix caching + manual UTF-8 conversion with byte array re-usage
+        var start = System.nanoTime()
+        val h1 = fastStringHash.hash(str, 0, str.length, 0)
+        time1 += System.nanoTime() - start
+
+        // allocation of new array for Java char to UTF-8 bytes
+        start = System.nanoTime()
+        val h2 = VowpalWabbitMurmur.hash(prefix + str, 0)
+        time2 += System.nanoTime() - start
+
+        //
+        start = System.nanoTime()
+        val bytes = (prefix + str).getBytes(StandardCharsets.UTF_8)
+        val h3 = VowpalWabbitMurmur.hashNative(bytes, 0, bytes.length, 0)
+        time3 += System.nanoTime() - start
+
+        assert(h1 == h2)
+        assert(h1 == h3)
+      }
+    }
+
+    println(s"FastStringHashing:   $time1")
+    println(s"Java String to UTF8: $time2")
+    println(s"Java to C++:         $time3")
+  }
+
+  test("Verify VowpalWabbitMurmurWithPrefix verify max-size exceed") {
+    val fastStringHash = new VowpalWabbitMurmurWithPrefix("a", 2)
+
+    val longStr = (1 to 32).mkString("_")
+
+    assert(fastStringHash.hash(longStr, 0) == VowpalWabbitMurmur.hash("a" + longStr, 0))
+  }
+
+  def verifyHashesAreTheSame(): Unit = {
+    Seq("\u0900def", "\ud800\udc00def").foreach { unicodeString =>
+      test(s"Verify VowpalWabbitMurmurWithPrefix verify unicode $unicodeString") {
+        val fastStringHash = new VowpalWabbitMurmurWithPrefix("abc")
+
+        assert(fastStringHash.hash(unicodeString, 0) == VowpalWabbitMurmur.hash("abc" + unicodeString, 0))
+      }
+    }
+  }
+
+  test("VowpalWabbitMurmurWithPrefix invalid unicode string") {
+    assertThrows[Exception] {
+      new VowpalWabbitMurmurWithPrefix("abc").hash("\ud800def", 0)
+    }
+  }
+}

--- a/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitRegressor.scala
+++ b/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitRegressor.scala
@@ -1,0 +1,134 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.test.base.TestBase
+import com.microsoft.ml.spark.core.test.benchmarks.{Benchmarks, DatasetUtils}
+import org.apache.spark.ml.evaluation.RegressionEvaluator
+import org.apache.spark.sql.{Column, DataFrame}
+
+class VerifyVowpalWabbitRegressor extends Benchmarks {
+
+  val args = Array("", "--bfgs", "--adaptive")
+
+  val numPartitions = 2
+
+  verifyLearnerOnRegressionCsvFile("energyefficiency2012_data.train.csv", "Y1", 0,
+    Some("X1,X2,X3,X4,X5,X6,X7,X8,Y1,Y2"))
+  verifyLearnerOnRegressionCsvFile("airfoil_self_noise.train.csv", "Scaled sound pressure level", 1)
+  verifyLearnerOnRegressionCsvFile("Buzz.TomsHardware.train.csv", "Mean Number of display (ND)", -3)
+  verifyLearnerOnRegressionCsvFile("machine.train.csv", "ERP", -2)
+  verifyLearnerOnRegressionCsvFile("Concrete_Data.train.csv", "Concrete compressive strength(MPa, megapascals)", 0)
+
+  /** Reads a CSV file given the file name and file location.
+    * @param fileName The name of the csv file.
+    * @param fileLocation The full path to the csv file.
+    * @return A dataframe from read CSV file.
+    */
+  def readCSV(fileName: String, fileLocation: String): DataFrame = {
+    session.read
+      .option("header", "true").option("inferSchema", "true")
+      .option("treatEmptyValuesAsNulls", "false")
+      .option("delimiter", if (fileName.endsWith(".csv")) "," else "\t")
+      .csv(fileLocation)
+  }
+
+  def verifyLearnerOnRegressionCsvFile(fileName: String,
+                                       labelCol: String,
+                                       decimals: Int,
+                                       columnsFilter: Option[String] = None): Unit = {
+    args.foreach { arg =>
+      val argText = s" with args $arg"
+      val testText = "Verify VowpalWabbitRegressor can be trained and scored on "
+      test(testText + fileName + argText, TestBase.Extended) {
+        val fileLocation = DatasetUtils.regressionTrainFile(fileName).toString
+        val readDataset = readCSV(fileName, fileLocation).repartition(numPartitions)
+        val dataset =
+          if (columnsFilter.isDefined) {
+            readDataset.select(columnsFilter.get.split(",").map(new Column(_)): _*)
+          } else {
+            readDataset
+          }
+
+        val featuresColumn = "features"
+
+        val featurizer = new VowpalWabbitFeaturizer()
+          .setInputCols(dataset.columns.filter(col => col != labelCol))
+          .setOutputCol("features")
+
+        val vw = new VowpalWabbitRegressor()
+        val predCol = "pred"
+        val trainData = featurizer.transform(dataset)
+        val model = vw.setLabelCol(labelCol)
+          .setFeaturesCol(featuresColumn)
+          .setPredictionCol(predCol)
+          .setNumPasses(3)
+          .setArgs(s" $arg --quiet")
+          .fit(trainData)
+        val scoredResult = model.transform(trainData).drop(featuresColumn)
+
+        val eval = new RegressionEvaluator()
+          .setLabelCol(labelCol)
+          .setPredictionCol(predCol)
+          .setMetricName("rmse")
+        val metric = eval.evaluate(scoredResult)
+        addBenchmark(s"VowpalWabbitRegressor_${fileName}_${arg}",
+          metric, decimals, false)
+      }
+    }
+  }
+
+  test("Compare benchmark results file to generated file", TestBase.Extended) {
+    verifyBenchmarks()
+  }
+
+  test("Verify multiple input columns") {
+    val fileName = "energyefficiency2012_data.train.csv"
+    val columnsFilter = Some("X1,X2,X3,X4,X5,X6,X7,X8,Y1,Y2")
+    val labelCol = "Y1"
+
+    val fileLocation = DatasetUtils.regressionTrainFile(fileName).toString
+    val readDataset = readCSV(fileName, fileLocation).repartition(numPartitions)
+    val dataset =
+      if (columnsFilter.isDefined) {
+        readDataset.select(columnsFilter.get.split(",").map(new Column(_)): _*)
+      } else {
+        readDataset
+      }
+
+    val featuresColumn = "features"
+
+    val featurizer = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("X1", "X2"))
+      .setOutputCol("a")
+
+    val featurizer2 = new VowpalWabbitFeaturizer()
+      .setInputCols(Array("X3", "X4"))
+      .setOutputCol("b")
+
+    val trainData =
+      featurizer2.transform(featurizer.transform(dataset))
+      .coalesce(1)
+
+    val vw = new VowpalWabbitRegressor()
+    val predCol = "pred"
+    val model = vw.setLabelCol(labelCol)
+      .setFeaturesCol("a")
+      .setAdditionalFeatures(Array("b"))
+      .setPredictionCol(predCol)
+      //.setArgs(s"-a") // don't pass -a (audit) when using interactions...
+      .setArgs("--quiet")
+      .setInteractions(Array("ab"))
+      .fit(trainData)
+    val scoredResult = model.transform(trainData).drop(featuresColumn)
+
+    val eval = new RegressionEvaluator()
+      .setLabelCol(labelCol)
+      .setPredictionCol(predCol)
+      .setMetricName("rmse")
+    val metric = eval.evaluate(scoredResult)
+
+    assert (metric < 11)
+  }
+}

--- a/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitRegressorFuzzing.scala
+++ b/src/test/scala/com/microsoft/ml/spark/vw/VerifyVowpalWabbitRegressorFuzzing.scala
@@ -1,0 +1,64 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.vw
+
+import com.microsoft.ml.spark.core.test.benchmarks.DatasetUtils
+import com.microsoft.ml.spark.core.test.fuzzing.{EstimatorFuzzing, TestObject}
+import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.sql.{Column, DataFrame}
+
+class VerifyVowpalWabbitRegressorFuzzing extends EstimatorFuzzing[VowpalWabbitRegressor] {
+  val numPartitions = 2
+
+  /** Reads a CSV file given the file name and file location.
+    *
+    * @param fileName     The name of the csv file.
+    * @param fileLocation The full path to the csv file.
+    * @return A dataframe from read CSV file.
+    */
+  def readCSV(fileName: String, fileLocation: String): DataFrame = {
+    session.read
+      .option("header", "true").option("inferSchema", "true")
+      .option("treatEmptyValuesAsNulls", "false")
+      .option("delimiter", if (fileName.endsWith(".csv")) "," else "\t")
+      .csv(fileLocation)
+  }
+
+  override def reader: MLReadable[_] = VowpalWabbitRegressor
+
+  override def modelReader: MLReadable[_] = VowpalWabbitRegressorModel
+
+  override def testObjects(): Seq[TestObject[VowpalWabbitRegressor]] = {
+    val fileName = "energyefficiency2012_data.train.csv"
+    val columnsFilter = Some("X1,X2,X3,X4,X5,X6,X7,X8,Y1,Y2")
+    val labelCol = "Y1"
+
+    val fileLocation = DatasetUtils.regressionTrainFile(fileName).toString
+    val readDataset = readCSV(fileName, fileLocation).repartition(numPartitions)
+    val dataset =
+      if (columnsFilter.isDefined) {
+        readDataset.select(columnsFilter.get.split(",").map(new Column(_)): _*)
+      } else {
+        readDataset
+      }
+
+    val featuresColumn = "features"
+
+    val featurizer = new VowpalWabbitFeaturizer()
+      .setInputCols(dataset.columns.filter(col => col != labelCol))
+      .setOutputCol("features")
+
+    val vw = new VowpalWabbitRegressor()
+    val predCol = "pred"
+    val trainData = featurizer.transform(dataset)
+    val model = vw.setLabelCol(labelCol)
+      .setFeaturesCol("features")
+      .setPredictionCol(predCol)
+      .fit(trainData)
+
+    Seq(new TestObject(
+      vw,
+      trainData))
+  }
+}


### PR DESCRIPTION
* Seamless ingestion of Spark Dataframes holding SparkML vectors (sparse and dense)
* Distributed data parallel learning support using VW's AllReduce. Parallelization configurable through number of data frame partitions
* Binary classification and regression support (probably more coming)
* VW namespace support through multiple columns (use addAdditionalColumns to pass multiple namespaces; column names are namespace names)
* VW native interaction term support (quadratics, cubics, ...) based on namespaces (=multiple columns)
* VW style featurization using VowpalWabbitFeaturizer. Supports numerics, strings, array of string, map of string to numerics. Very useful to keep featurization compatibility with regular VW for inference scenarios
* Java/JNI bindings include Boost dependencies (Linux only) to avoid deployment mess