### PR TITLE
fix: update lightgbm to 2.2.400, fix probabilities and some windows errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "com.jcraft" % "jsch" % "0.1.54",
   "com.jcraft" % "jsch" % "0.1.54",
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
-  "com.microsoft.ml.lightgbm" % "lightgbmlib" % "2.2.350",
+  "com.microsoft.ml.lightgbm" % "lightgbmlib" % "2.2.400",
   "com.github.vowpalwabbit" %  "vw-jni" % "8.7.0.2"
 )
 

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainUtils.scala
@@ -149,11 +149,8 @@ private object TrainUtils extends Serializable {
 
   def saveBoosterToString(boosterPtr: Option[SWIGTYPE_p_void], log: Logger): String = {
     val bufferLength = LightGBMConstants.DefaultBufferLength
-    val bufferLengthPtr = lightgbmlib.new_longp()
-    lightgbmlib.longp_assign(bufferLengthPtr, bufferLength)
-    val bufferLengthPtrInt64 = lightgbmlib.long_to_int64_t_ptr(bufferLengthPtr)
     val bufferOutLengthPtr = lightgbmlib.new_int64_tp()
-    lightgbmlib.LGBM_BoosterSaveModelToStringSWIG(boosterPtr.get, 0, -1, bufferLengthPtrInt64, bufferOutLengthPtr)
+    lightgbmlib.LGBM_BoosterSaveModelToStringSWIG(boosterPtr.get, 0, -1, bufferLength, bufferOutLengthPtr)
   }
 
   def getEvalNames(boosterPtr: Option[SWIGTYPE_p_void]): Array[String] = {


### PR DESCRIPTION
update lightgbm to 2.2.400 - recently uploaded maven artifact of latest lightgbm build
includes fixes:
1.) Fix lightgbm swig wrapper on windows - now most windows tests will pass.  Not re-enabling windows tests yet because I am still seeing a test failure,but the majority of tests seem to pass now.
https://github.com/microsoft/LightGBM/pull/2364
2.) fix cached predictor causing bad probability values
https://github.com/microsoft/LightGBM/pull/2356
3.) exponential backoff for MPI ring connection, should improve test times significantly
https://github.com/microsoft/LightGBM/pull/2354