### PR TITLE
feat: add eval_at parameter to lightgbm ranker

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
@@ -42,13 +42,19 @@ class LightGBMRanker(override val uid: String)
   def getLabelGain: Array[Double] = $(labelGain)
   def setLabelGain(value: Array[Double]): this.type = set(labelGain, value)
 
+  val evalAt = new IntArrayParam(this, "evalAt", "NDCG and MAP evaluation positions, separated by comma")
+  setDefault(evalAt -> (1 to 5).toArray)
+
+  def getEvalAt: Array[Int] = $(evalAt)
+  def setEvalAt(value: Array[Int]): this.type = set(evalAt, value)
+
   def getTrainParams(numWorkers: Int, categoricalIndexes: Array[Int], dataset: Dataset[_]): TrainParams = {
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
     RankerTrainParams(getParallelism, getNumIterations, getLearningRate, getNumLeaves,
       getObjective, getMaxBin, getBaggingFraction, getBaggingFreq, getBaggingSeed, getEarlyStoppingRound,
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numWorkers, modelStr,
       getVerbosity, categoricalIndexes, getBoostingType, getLambdaL1, getLambdaL2, getMaxPosition, getLabelGain,
-      getIsProvideTrainingMetric, getMetric)
+      getIsProvideTrainingMetric, getMetric, getEvalAt)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRankerModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainParams.scala
@@ -93,11 +93,13 @@ case class RankerTrainParams(parallelism: String, numIterations: Int, learningRa
                              categoricalFeatures: Array[Int], boostingType: String,
                              lambdaL1: Double, lambdaL2: Double, maxPosition: Int,
                              labelGain: Array[Double], isProvideTrainingMetric: Boolean,
-                             metric: String)
+                             metric: String, evalAt: Array[Int])
   extends TrainParams {
   override def toString(): String = {
     val labelGainStr =
       if (labelGain.isEmpty) "" else s"label_gain=${labelGain.mkString(",")}"
-    s"max_position=$maxPosition $labelGainStr ${super.toString()}"
+    val evalAtStr =
+      if (evalAt.isEmpty) "" else s"eval_at=${evalAt.mkString(",")}"
+    s"max_position=$maxPosition $labelGainStr $evalAtStr ${super.toString()}"
   }
 }

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split2/VerifyLightGBMRanker.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split2/VerifyLightGBMRanker.scala
@@ -100,8 +100,9 @@ class VerifyLightGBMRanker extends Benchmarks with EstimatorFuzzing[LightGBMRank
       .transform(baseDF)
       .select(queryCol, labelCol, featuresCol)
 
-    assertFitWithoutErrors(baseModel, df)
-    assertFitWithoutErrors(baseModel, df.withColumn(queryCol, col(queryCol).cast("Int")))
+    assertFitWithoutErrors(baseModel.setEvalAt(1 to 3 toArray), df)
+    assertFitWithoutErrors(baseModel.setEvalAt(1 to 3 toArray),
+      df.withColumn(queryCol, col(queryCol).cast("Int")))
   }
 
   override def testObjects(): Seq[TestObject[LightGBMRanker]] = {


### PR DESCRIPTION
for user request, to be able to use NDCG@N: https://github.com/Azure/mmlspark/pull/672

