### PR TITLE
fix: cast errors for label, weight and init score columns

### DIFF
--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -262,7 +262,15 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     }
 
     // Verify changing weight of one label significantly skews the results
-    assert(countPredictions(df) * 2 < countPredictions(dfWeight))
+    val constLabelPredictionCount = countPredictions(df)
+    assert(constLabelPredictionCount * 2 < countPredictions(dfWeight))
+
+    // Also validate with int and long values for weight column predictions are the same within some threshold
+    val threshold = 0.2 * constLabelPredictionCount
+    val dfInt = pimaDF.withColumn(weightCol, lit(1))
+    assert(math.abs(constLabelPredictionCount - countPredictions(dfInt)) < threshold)
+    val dfLong = pimaDF.withColumn(weightCol, lit(1L))
+    assert(math.abs(constLabelPredictionCount - countPredictions(dfLong)) < threshold)
   }
 
   test("Verify LightGBM Classifier with unbalanced dataset") {


### PR DESCRIPTION
created a new PR based on review for https://github.com/Azure/mmlspark/pull/688

fixes #682 based on user feedback

User may receive error that can be difficult to track down if they pass non-double column for label, weight or init score (int or long), so we just cast it to double for them if it is not already a double type column for convenience