### PR TITLE
fix: lightgbm binary classifier getting stuck due to single label in some partitions

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
@@ -8,7 +8,7 @@ import com.microsoft.ml.spark.core.serialize.{ConstructorReadable, ConstructorWr
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.classification.{ProbabilisticClassificationModel, ProbabilisticClassifier}
-import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, udf}
 


### PR DESCRIPTION
fix lightgbm binary classifier getting stuck due to single label in some partitions

By default, lightgbm will now fail with exception message instead of timing out with connection refused error when some workers only have a single class and exit early during training.