### PR TITLE
docs: Change labelGain description

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
@@ -36,7 +36,7 @@ class LightGBMRanker(override val uid: String)
   def getMaxPosition: Int = $(maxPosition)
   def setMaxPosition(value: Int): this.type = set(maxPosition, value)
 
-  val labelGain = new DoubleArrayParam(this, "labelGain", "parameter for Huber loss and Quantile regression")
+  val labelGain = new DoubleArrayParam(this, "labelGain", "graded relevance for each label in NDCG")
   setDefault(labelGain -> Array.empty[Double])
 
   def getLabelGain: Array[Double] = $(labelGain)


### PR DESCRIPTION
The description of labelGain hyper-parameter was not correct and has been corrected. Actually, it looked like the one corresponding to alpha hyper-parameter.

No change in behaviour. Just a small change in documentation