### PR TITLE
fix: Guarantee one boosterPtr is allocated and freed per LightGBMBooster instance

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBooster.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBooster.scala
@@ -86,20 +86,6 @@ protected class BoosterHandler(model: String) {
       "Booster NumFeature")
    lightgbmlib.intp_value(numFeaturesOut)
   }
-
-  override def finalize(): Unit = {
-    if (scoredDataLengthLongPtr != null)
-      lightgbmlib.delete_int64_tp(scoredDataLengthLongPtr)
-    if (scoredDataOutPtr != null)
-      lightgbmlib.delete_doubleArray(scoredDataOutPtr)
-    if (leafIndexDataLengthLongPtr != null)
-      lightgbmlib.delete_int64_tp(leafIndexDataLengthLongPtr)
-    if (leafIndexDataOutPtr != null)
-      lightgbmlib.delete_doubleArray(leafIndexDataOutPtr)
-    if (boosterPtr != null) {
-      LightGBMUtils.validate(lightgbmlib.LGBM_BoosterFree(boosterPtr), "Finalize Booster")
-    }
-  }
 }
 
 /** Represents a LightGBM Booster learner

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBooster.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBooster.scala
@@ -45,7 +45,7 @@ protected class BoosterHandler(model: String) {
   lazy val numTotalModelPerIteration = getNumModelPerIteration
 
   lazy val rawScoreConstant = lightgbmlibConstants.C_API_PREDICT_RAW_SCORE
-  lazy val normalScoreConstant = lightgbmlibConstants.C_API_PREDICT_RAW_SCORE
+  lazy val normalScoreConstant = lightgbmlibConstants.C_API_PREDICT_NORMAL
   lazy val leafIndexPredictConstant = lightgbmlibConstants.C_API_PREDICT_LEAF_INDEX
 
   lazy val dataInt32bitType = lightgbmlibConstants.C_API_DTYPE_INT32

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
@@ -212,7 +212,7 @@ object LightGBMClassificationModel extends ConstructorReadable[LightGBMClassific
     val textRdd = session.read.text(filename)
     val text = textRdd.collect().map { row => row.getString(0) }.mkString("\n")
     val lightGBMBooster = new LightGBMBooster(text)
-    val actualNumClasses = lightGBMBooster.getNumClasses()
+    val actualNumClasses = lightGBMBooster.numClasses
     new LightGBMClassificationModel(uid, lightGBMBooster, labelColName, featuresColName,
       predictionColName, probColName, rawPredictionColName, leafPredictionColName, None, actualNumClasses)
   }
@@ -224,7 +224,7 @@ object LightGBMClassificationModel extends ConstructorReadable[LightGBMClassific
                                 leafPredictionColName: String = "leafPrediction"): LightGBMClassificationModel = {
     val uid = Identifiable.randomUID("LightGBMClassifier")
     val lightGBMBooster = new LightGBMBooster(model)
-    val actualNumClasses = lightGBMBooster.getNumClasses()
+    val actualNumClasses = lightGBMBooster.numClasses
     new LightGBMClassificationModel(uid, lightGBMBooster, labelColName, featuresColName,
       predictionColName, probColName, rawPredictionColName, leafPredictionColName, None, actualNumClasses)
   }


### PR DESCRIPTION
I am not sure this is a fix, and not sure about the potential performance implications.

I think these changes could be helpful in solving memory issues that seem related to concurrency in spark such as https://github.com/microsoft/LightGBM/issues/2392.

Please feel free to comment, is just a proposal but I am not 100% sure that it fixes these issues.