### PR TITLE
fix: spark.executor.cores' default value based on master when counting workers

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/core/utils/ClusterUtil.scala
+++ b/src/main/scala/com/microsoft/ml/spark/core/utils/ClusterUtil.scala
@@ -38,7 +38,7 @@ object ClusterUtil {
   }
 
   /** Get number of default cores from sparkSession(required) or master(optional) for 1 executor.
-    * @param spark The current spark session. If not set master param, the master in the session is used.
+    * @param spark The current spark session. If master parameter is not set, the master in the spark session is used.
     * @param master This param is needed for unittest. If set, the function return the value for it.
     *               if not set, basically, master in spark (SparkSession) is used.
     * @return The number of default cores per executor based on master.

--- a/src/test/scala/com/microsoft/ml/spark/core/test/base/SparkSessionFactory.scala
+++ b/src/test/scala/com/microsoft/ml/spark/core/test/base/SparkSessionFactory.scala
@@ -34,7 +34,7 @@ object SparkSessionFactory {
   def currentDir(): String = System.getProperty("user.dir")
 
   def getSession(name: String, logLevel: String = "WARN",
-                 numRetries: Int, numCores: Option[Int] = None): SparkSession = {
+                 numRetries: Int = 0, numCores: Option[Int] = None): SparkSession = {
     val cores = numCores.map(_.toString).getOrElse("*")
     val conf = new SparkConf()
         .setAppName(name)

--- a/src/test/scala/com/microsoft/ml/spark/core/utils/VerifyClusterUtil.scala
+++ b/src/test/scala/com/microsoft/ml/spark/core/utils/VerifyClusterUtil.scala
@@ -1,3 +1,6 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
 package com.microsoft.ml.spark.core.utils
 
 import com.microsoft.ml.spark.core.test.base.{SparkSessionFactory, TestBase}

--- a/src/test/scala/com/microsoft/ml/spark/core/utils/VerifyClusterUtil.scala
+++ b/src/test/scala/com/microsoft/ml/spark/core/utils/VerifyClusterUtil.scala
@@ -1,0 +1,16 @@
+package com.microsoft.ml.spark.core.utils
+
+import com.microsoft.ml.spark.core.test.base.{SparkSessionFactory, TestBase}
+import org.slf4j.LoggerFactory
+
+class VerifyClusterUtil extends TestBase {
+  test("Verify ClusterUtil can get default number of executor cores based on master") {
+    val spark = SparkSessionFactory.getSession("verifyClusterUtil-Session")
+    val log = LoggerFactory.getLogger("VerifyClusterUtil")
+
+    // https://spark.apache.org/docs/latest/configuration.html
+    assert(ClusterUtil.getDefaultNumExecutorCores(spark, log, Option("yarn")) == 1)
+    assert(ClusterUtil.getDefaultNumExecutorCores(spark, log, Option("spark://localhost:7077")) ==
+      ClusterUtil.getJVMCPUs(spark))
+  }
+}


### PR DESCRIPTION
This pr is fixing spark.executor.cores' default value based on master when counting workers.

The default value of spark.executor.cores is different as what master is.

It is 1 in YARN mode. In other case, It is all the available cores on the worker in standalone and Mesos coarse-grained modes.
(https://spark.apache.org/docs/latest/configuration.html)

Currently, I've tried to use mmlspark based on spark on k8s. When I did not set spark.executor.cores, error was occured. It is because not matched expected num of mmlspark workers with actual value.