### PR TITLE
feat: unify APIs across LightGBM learner types and add SHAP feature importances to regressor

### DIFF
--- a/src/main/python/mmlspark/lightgbm/LightGBMClassifier.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMClassifier.py
@@ -32,31 +32,23 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         self._java_obj.saveNativeModel(filename, overwrite)
 
     @staticmethod
-    def loadNativeModelFromFile(filename, labelColName="label",
-                                featuresColName="features", predictionColName="prediction",
-                                probColName="probability", rawPredictionColName="rawPrediction"):
+    def loadNativeModelFromFile(filename):
         """
         Load the model from a native LightGBM text file.
         """
         ctx = SparkContext._active_spark_context
         loader = ctx._jvm.com.microsoft.ml.spark.lightgbm.LightGBMClassificationModel
-        java_model = loader.loadNativeModelFromFile(filename, labelColName,
-                                                    featuresColName, predictionColName,
-                                                    probColName, rawPredictionColName)
+        java_model = loader.loadNativeModelFromFile(filename)
         return JavaParams._from_java(java_model)
 
     @staticmethod
-    def loadNativeModelFromString(model, labelColName="label",
-                                  featuresColName="features", predictionColName="prediction",
-                                  probColName="probability", rawPredictionColName="rawPrediction"):
+    def loadNativeModelFromString(model):
         """
         Load the model from a native LightGBM model string.
         """
         ctx = SparkContext._active_spark_context
         loader = ctx._jvm.com.microsoft.ml.spark.lightgbm.LightGBMClassificationModel
-        java_model = loader.loadNativeModelFromString(model, labelColName,
-                                                      featuresColName, predictionColName,
-                                                      probColName, rawPredictionColName)
+        java_model = loader.loadNativeModelFromString(model)
         return JavaParams._from_java(java_model)
 
     def getFeatureImportances(self, importance_type="split"):
@@ -64,3 +56,15 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         Get the feature importances as a list.  The importance_type can be "split" or "gain".
         """
         return list(self._java_obj.getFeatureImportances(importance_type))
+
+    def getDenseFeatureShaps(self, vector):
+        """
+        Get the local shap feature importances.
+        """
+        return list(self._java_obj.getFeatureShaps(vector))
+
+    def getSparseFeatureShaps(self, size, indices, values):
+        """
+        Get the local shap feature importances for sparse vectors.
+        """
+        return list(self._java_obj.getSparseFeatureShaps(size, indices, values))

--- a/src/main/python/mmlspark/lightgbm/LightGBMRanker.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMRanker.py
@@ -32,27 +32,23 @@ class LightGBMRankerModel(_LightGBMRankerModel):
         self._java_obj.saveNativeModel(filename, overwrite)
 
     @staticmethod
-    def loadNativeModelFromFile(filename, labelColName="label", featuresColName="features",
-                                predictionColName="prediction"):
+    def loadNativeModelFromFile(filename):
         """
         Load the model from a native LightGBM text file.
         """
         ctx = SparkContext._active_spark_context
         loader = ctx._jvm.com.microsoft.ml.spark.lightgbm.LightGBMRankerModel
-        java_model = loader.loadNativeModelFromFile(filename, labelColName,
-                                                    featuresColName, predictionColName)
+        java_model = loader.loadNativeModelFromFile(filename)
         return JavaParams._from_java(java_model)
 
     @staticmethod
-    def loadNativeModelFromString(model, labelColName="label", featuresColName="features",
-                                  predictionColName="prediction"):
+    def loadNativeModelFromString(model):
         """
         Load the model from a native LightGBM model string.
         """
         ctx = SparkContext._active_spark_context
         loader = ctx._jvm.com.microsoft.ml.spark.lightgbm.LightGBMRankerModel
-        java_model = loader.loadNativeModelFromString(model, labelColName,
-                                                      featuresColName, predictionColName)
+        java_model = loader.loadNativeModelFromString(model)
         return JavaParams._from_java(java_model)
 
     def getFeatureImportances(self, importance_type="split"):
@@ -60,3 +56,15 @@ class LightGBMRankerModel(_LightGBMRankerModel):
         Get the feature importances as a list.  The importance_type can be "split" or "gain".
         """
         return list(self._java_obj.getFeatureImportances(importance_type))
+
+    def getDenseFeatureShaps(self, vector):
+        """
+        Get the local shap feature importances.
+        """
+        return list(self._java_obj.getFeatureShaps(vector))
+
+    def getSparseFeatureShaps(self, size, indices, values):
+        """
+        Get the local shap feature importances for sparse vectors.
+        """
+        return list(self._java_obj.getSparseFeatureShaps(size, indices, values))

--- a/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
@@ -32,27 +32,23 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
         self._java_obj.saveNativeModel(filename, overwrite)
 
     @staticmethod
-    def loadNativeModelFromFile(filename, labelColName="label", featuresColName="features",
-                                predictionColName="prediction"):
+    def loadNativeModelFromFile(filename):
         """
         Load the model from a native LightGBM text file.
         """
         ctx = SparkContext._active_spark_context
         loader = ctx._jvm.com.microsoft.ml.spark.lightgbm.LightGBMRegressionModel
-        java_model = loader.loadNativeModelFromFile(filename, labelColName,
-                                                    featuresColName, predictionColName)
+        java_model = loader.loadNativeModelFromFile(filename)
         return JavaParams._from_java(java_model)
 
     @staticmethod
-    def loadNativeModelFromString(model, labelColName="label", featuresColName="features",
-                                  predictionColName="prediction"):
+    def loadNativeModelFromString(model):
         """
         Load the model from a native LightGBM model string.
         """
         ctx = SparkContext._active_spark_context
         loader = ctx._jvm.com.microsoft.ml.spark.lightgbm.LightGBMRegressionModel
-        java_model = loader.loadNativeModelFromString(model, labelColName,
-                                                      featuresColName, predictionColName)
+        java_model = loader.loadNativeModelFromString(model)
         return JavaParams._from_java(java_model)
 
     def getFeatureImportances(self, importance_type="split"):
@@ -60,3 +56,15 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
         Get the feature importances as a list.  The importance_type can be "split" or "gain".
         """
         return list(self._java_obj.getFeatureImportances(importance_type))
+
+    def getDenseFeatureShaps(self, vector):
+        """
+        Get the local shap feature importances.
+        """
+        return list(self._java_obj.getFeatureShaps(vector))
+
+    def getSparseFeatureShaps(self, size, indices, values):
+        """
+        Get the local shap feature importances for sparse vectors.
+        """
+        return list(self._java_obj.getSparseFeatureShaps(size, indices, values))

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBoosterParam.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBoosterParam.scala
@@ -1,0 +1,19 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm
+
+import com.microsoft.ml.spark.core.serialize.ComplexParam
+import org.apache.spark.ml.param.Params
+
+/** Custom ComplexParam for LightGBMBooster, to make it settable on the LightGBM models.
+  */
+class LightGBMBoosterParam(parent: Params, name: String, doc: String,
+                        isValid: LightGBMBooster => Boolean)
+
+  extends ComplexParam[LightGBMBooster](parent, name, doc, isValid) {
+
+  def this(parent: Params, name: String, doc: String) =
+    this(parent, name, doc, {_ => true})
+
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
@@ -4,15 +4,13 @@
 package com.microsoft.ml.spark.lightgbm
 
 import com.microsoft.ml.spark.core.env.InternalWrapper
-import com.microsoft.ml.spark.core.serialize.{ConstructorReadable, ConstructorWritable}
+import org.apache.spark.ml.{ComplexParamsReadable, ComplexParamsWritable}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.classification.{ProbabilisticClassificationModel, ProbabilisticClassifier}
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, udf}
-
-import scala.reflect.runtime.universe.{TypeTag, typeTag}
 
 object LightGBMClassifier extends DefaultParamsReadable[LightGBMClassifier]
 
@@ -25,8 +23,7 @@ object LightGBMClassifier extends DefaultParamsReadable[LightGBMClassifier]
 @InternalWrapper
 class LightGBMClassifier(override val uid: String)
   extends ProbabilisticClassifier[Vector, LightGBMClassifier, LightGBMClassificationModel]
-  with LightGBMBase[LightGBMClassificationModel]
-  with HasLeafPredictionCol with HasFeaturesShapCol {
+  with LightGBMBase[LightGBMClassificationModel] {
   def this() = this(Identifiable.randomUID("LightGBMClassifier"))
 
   // Set default objective to be binary classification
@@ -56,9 +53,16 @@ class LightGBMClassifier(override val uid: String)
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {
     val classifierTrainParams = trainParams.asInstanceOf[ClassifierTrainParams]
-    new LightGBMClassificationModel(uid, lightGBMBooster, getLabelCol, getFeaturesCol,
-      getPredictionCol, getProbabilityCol, getRawPredictionCol, getLeafPredictionCol, getFeaturesShapCol,
-      if (isDefined(thresholds)) Some(getThresholds) else None, classifierTrainParams.numClass)
+    val model = new LightGBMClassificationModel(uid)
+      .setLightGBMBooster(lightGBMBooster)
+      .setFeaturesCol(getFeaturesCol)
+      .setPredictionCol(getPredictionCol)
+      .setProbabilityCol(getProbabilityCol)
+      .setRawPredictionCol(getRawPredictionCol)
+      .setLeafPredictionCol(getLeafPredictionCol)
+      .setFeaturesShapCol(getFeaturesShapCol)
+      .setActualNumClasses(classifierTrainParams.numClass)
+    if (isDefined(thresholds)) model.setThresholds(getThresholds) else model
   }
 
   def stringFromTrainedModel(model: LightGBMClassificationModel): String = {
@@ -68,58 +72,22 @@ class LightGBMClassifier(override val uid: String)
   override def copy(extra: ParamMap): LightGBMClassifier = defaultCopy(extra)
 }
 
-trait HasFeatureImportanceGetters {
-  val model: LightGBMBooster
+/** Special parameter for classification model for actual number of classes in dataset
+  */
+trait HasActualNumClasses extends Params {
+  val actualNumClasses = new IntParam(this, "actualNumClasses",
+    "Inferred number of classes based on dataset metadata or, if there is no metadata, unique count")
 
-  def getFeatureImportances(importanceType: String): Array[Double] = {
-    model.getFeatureImportances(importanceType)
-  }
-
-}
-
-trait HasLeafPredictionCol extends Params {
-  val leafPredictionCol = new Param[String](this, "leafPredictionCol",
-    "Predicted leaf indices's column name")
-  setDefault(leafPredictionCol -> "")
-
-  def getLeafPredictionCol: String = $(leafPredictionCol)
-  def setLeafPredictionCol(value: String): this.type = set(leafPredictionCol, value)
-}
-
-trait HasFeaturesShapCol extends Params {
-  val featuresShapCol = new Param[String](this, "featuresShapCol",
-    "Output SHAP vector column name after prediction containing the feature contribution values")
-  setDefault(featuresShapCol -> "")
-
-  def getFeaturesShapCol: String = $(featuresShapCol)
-  def setFeaturesShapCol(value: String): this.type = set(featuresShapCol, value)
+  def getActualNumClasses: Int = $(actualNumClasses)
+  def setActualNumClasses(value: Int): this.type = set(actualNumClasses, value)
 }
 
 /** Model produced by [[LightGBMClassifier]]. */
 @InternalWrapper
-class LightGBMClassificationModel(
-  override val uid: String, override val model: LightGBMBooster, labelColName: String,
-  featuresColName: String, predictionColName: String, probColName: String,
-  rawPredictionColName: String, leafPredictionColName: String, featuresShapColName: String,
-  thresholdValues: Option[Array[Double]],
-  actualNumClasses: Int)
+class LightGBMClassificationModel(override val uid: String)
     extends ProbabilisticClassificationModel[Vector, LightGBMClassificationModel]
-    with HasFeatureImportanceGetters
-    with HasLeafPredictionCol
-    with HasFeaturesShapCol
-    with ConstructorWritable[LightGBMClassificationModel] {
-
-  // Update the underlying Spark ML com.microsoft.ml.spark.core.serialize.params
-  // (for proper serialization to work we put them on constructor instead of using copy as in Spark ML)
-  set(labelCol, labelColName)
-  set(featuresCol, featuresColName)
-  set(predictionCol, predictionColName)
-  set(probabilityCol, probColName)
-  set(rawPredictionCol, rawPredictionColName)
-  set(leafPredictionCol, leafPredictionColName)
-  set(featuresShapCol, featuresShapColName)
-
-  if (thresholdValues.isDefined) set(thresholds, thresholdValues.get)
+      with LightGBMModelParams with LightGBMModelMethods with LightGBMPredictionParams
+      with HasActualNumClasses with ComplexParamsWritable {
 
   /**
     * Implementation based on ProbabilisticClassifier with slight modifications to
@@ -178,27 +146,17 @@ class LightGBMClassificationModel(
       " raw2probabilityInPlace should not be called!")
   }
 
-  override def numClasses: Int = this.actualNumClasses
+  override def numClasses: Int = getActualNumClasses
 
   override protected def predictRaw(features: Vector): Vector = {
-    Vectors.dense(model.score(features, true, true))
+    Vectors.dense(getModel.score(features, true, true))
   }
 
   override protected def predictProbability(features: Vector): Vector = {
-    Vectors.dense(model.score(features, false, true))
+    Vectors.dense(getModel.score(features, false, true))
   }
 
-  override def copy(extra: ParamMap): LightGBMClassificationModel =
-    new LightGBMClassificationModel(uid, model, labelColName, featuresColName, predictionColName, probColName,
-      rawPredictionColName, leafPredictionColName, featuresShapColName, thresholdValues, actualNumClasses)
-
-  override val ttag: TypeTag[LightGBMClassificationModel] =
-    typeTag[LightGBMClassificationModel]
-
-  override def objectsToSave: List[Any] =
-    List(uid, model, getLabelCol, getFeaturesCol, getPredictionCol,
-         getProbabilityCol, getRawPredictionCol, getLeafPredictionCol,
-         getFeaturesShapCol, thresholdValues, actualNumClasses)
+  override def copy(extra: ParamMap): LightGBMClassificationModel = defaultCopy(extra)
 
   protected def predictColumn: Column = {
     if (getRawPredictionCol.nonEmpty && !isDefined(thresholds)) {
@@ -211,51 +169,27 @@ class LightGBMClassificationModel(
     }
   }
 
-  protected def predictLeaf(features: Vector): Vector = {
-    Vectors.dense(model.predictLeaf(features))
-  }
-
-  protected def featuresShap(features: Vector): Vector = {
-    Vectors.dense(model.featuresShap(features))
-  }
-
   def saveNativeModel(filename: String, overwrite: Boolean): Unit = {
     val session = SparkSession.builder().getOrCreate()
-    model.saveNativeModel(session, filename, overwrite)
+    getModel.saveNativeModel(session, filename, overwrite)
   }
-
-  def getModel: LightGBMBooster = this.model
 }
 
-object LightGBMClassificationModel extends ConstructorReadable[LightGBMClassificationModel] {
-  def loadNativeModelFromFile(filename: String, labelColName: String = "label",
-                              featuresColName: String = "features", predictionColName: String = "prediction",
-                              probColName: String = "probability",
-                              rawPredictionColName: String = "rawPrediction",
-                              leafPredictionColName: String = "leafPrediction",
-                              featuresShapColName: String = "featuresShap"): LightGBMClassificationModel = {
+object LightGBMClassificationModel extends ComplexParamsReadable[LightGBMClassificationModel] {
+  def loadNativeModelFromFile(filename: String): LightGBMClassificationModel = {
     val uid = Identifiable.randomUID("LightGBMClassifier")
     val session = SparkSession.builder().getOrCreate()
     val textRdd = session.read.text(filename)
     val text = textRdd.collect().map { row => row.getString(0) }.mkString("\n")
     val lightGBMBooster = new LightGBMBooster(text)
     val actualNumClasses = lightGBMBooster.numClasses
-    new LightGBMClassificationModel(uid, lightGBMBooster, labelColName, featuresColName,
-      predictionColName, probColName, rawPredictionColName, leafPredictionColName, featuresShapColName,
-      None, actualNumClasses)
+    new LightGBMClassificationModel(uid).setLightGBMBooster(lightGBMBooster).setActualNumClasses(actualNumClasses)
   }
 
-  def loadNativeModelFromString(model: String, labelColName: String = "label",
-                                featuresColName: String = "features", predictionColName: String = "prediction",
-                                probColName: String = "probability",
-                                rawPredictionColName: String = "rawPrediction",
-                                leafPredictionColName: String = "leafPrediction",
-                                featuresShapColName: String = "featuresShap"): LightGBMClassificationModel = {
+  def loadNativeModelFromString(model: String): LightGBMClassificationModel = {
     val uid = Identifiable.randomUID("LightGBMClassifier")
     val lightGBMBooster = new LightGBMBooster(model)
     val actualNumClasses = lightGBMBooster.numClasses
-    new LightGBMClassificationModel(uid, lightGBMBooster, labelColName, featuresColName,
-      predictionColName, probColName, rawPredictionColName, leafPredictionColName, featuresShapColName,
-      None, actualNumClasses)
+    new LightGBMClassificationModel(uid).setLightGBMBooster(lightGBMBooster).setActualNumClasses(actualNumClasses)
   }
 }

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
@@ -1,0 +1,66 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm
+
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+
+/** Contains common LightGBM model methods across all LightGBM learner types.
+  */
+trait LightGBMModelMethods extends LightGBMModelParams {
+  /**
+    * Public method to get the global feature importance values.
+    * @param importanceType split or gini
+    * @return The global feature importance values.
+    */
+  def getFeatureImportances(importanceType: String): Array[Double] = {
+    getLightGBMBooster.getFeatureImportances(importanceType)
+  }
+
+  /**
+    * Public method to get the vector local SHAP feature importance values for an instance.
+    * @param features The local instance or row to compute the SHAP values for.
+    * @return The local feature importance values.
+    */
+  def getFeatureShaps(features: Vector): Array[Double] = {
+    getLightGBMBooster.featuresShap(features)
+  }
+
+  /**
+    * Public method to get the dense local SHAP feature importance values for an instance.
+    * @param features The local instance or row to compute the SHAP values for.
+    * @return The local feature importance values.
+    */
+  def getDenseFeatureShaps(features: Array[Double]): Array[Double] = {
+    getLightGBMBooster.featuresShap(Vectors.dense(features))
+  }
+
+  /**
+    * Public method to get the sparse local SHAP feature importance values for an instance.
+    * @param size: The size of the sparse vector.
+    * @param indices: The local instance or row indices to compute the SHAP values for.
+    * @param values: The local instance or row values to compute the SHAP values for.
+    * @return The local feature importance values.
+    */
+  def getSparseFeatureShaps(size: Int, indices: Array[Int], values: Array[Double]): Array[Double] = {
+    getLightGBMBooster.featuresShap(Vectors.sparse(size, indices, values))
+  }
+
+  /**
+    * Protected method to predict leaf index.
+    * @param features The local instance or row to compute the leaf index for.
+    * @return The predicted leaf index.
+    */
+  protected def predictLeaf(features: Vector): Vector = {
+    Vectors.dense(getLightGBMBooster.predictLeaf(features))
+  }
+
+  /**
+    * Protected method to predict local SHAP feature importance values for an instance.
+    * @param features The local instance or row to compute the local SHAP values for.
+    * @return The SHAP local feature importance values.
+    */
+  protected def featuresShap(features: Vector): Vector = {
+    Vectors.dense(getLightGBMBooster.featuresShap(features))
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
@@ -159,11 +159,46 @@ trait LightGBMFractionParams extends Wrappable {
   def setFeatureFraction(value: Double): this.type = set(featureFraction, value)
 }
 
+/** Defines common prediction parameters across LightGBM Ranker, Classifier and Regressor
+  */
+trait LightGBMPredictionParams extends Wrappable {
+  val leafPredictionCol = new Param[String](this, "leafPredictionCol",
+    "Predicted leaf indices's column name")
+  setDefault(leafPredictionCol -> "")
+
+  def getLeafPredictionCol: String = $(leafPredictionCol)
+  def setLeafPredictionCol(value: String): this.type = set(leafPredictionCol, value)
+
+  val featuresShapCol = new Param[String](this, "featuresShapCol",
+    "Output SHAP vector column name after prediction containing the feature contribution values")
+  setDefault(featuresShapCol -> "")
+
+  def getFeaturesShapCol: String = $(featuresShapCol)
+  def setFeaturesShapCol(value: String): this.type = set(featuresShapCol, value)
+}
+
+/** Defines parameters for LightGBM models
+  */
+trait LightGBMModelParams extends Wrappable {
+  val lightGBMBooster = new LightGBMBoosterParam(this, "lightGBMBooster",
+    "The trained LightGBM booster")
+
+  def getLightGBMBooster: LightGBMBooster = $(lightGBMBooster)
+  def setLightGBMBooster(value: LightGBMBooster): this.type = set(lightGBMBooster, value)
+
+  /**
+    * Alias for same method
+    * @return The LightGBM Booster.
+    */
+  def getModel: LightGBMBooster = this.getLightGBMBooster
+}
+
 /** Defines common parameters across all LightGBM learners.
   */
 trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeightCol
   with HasValidationIndicatorCol with HasInitScoreCol with LightGBMExecutionParams
-  with LightGBMSlotParams with LightGBMFractionParams with LightGBMBinParams with LightGBMLearnerParams {
+  with LightGBMSlotParams with LightGBMFractionParams with LightGBMBinParams with LightGBMLearnerParams
+  with LightGBMPredictionParams {
   val numIterations = new IntParam(this, "numIterations",
     "Number of iterations, LightGBM constructs num_class * num_iterations trees")
   setDefault(numIterations->100)

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
@@ -4,15 +4,13 @@
 package com.microsoft.ml.spark.lightgbm
 
 import com.microsoft.ml.spark.core.env.InternalWrapper
-import com.microsoft.ml.spark.core.serialize.{ConstructorReadable, ConstructorWritable}
-import org.apache.spark.ml.BaseRegressor
+import org.apache.spark.ml.{BaseRegressor, ComplexParamsReadable, ComplexParamsWritable}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.regression.RegressionModel
 import org.apache.spark.sql._
-
-import scala.reflect.runtime.universe.{TypeTag, typeTag}
+import org.apache.spark.sql.functions.{col, udf}
 
 object LightGBMRegressor extends DefaultParamsReadable[LightGBMRegressor]
 
@@ -68,7 +66,12 @@ class LightGBMRegressor(override val uid: String)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRegressionModel = {
-    new LightGBMRegressionModel(uid, lightGBMBooster, getLabelCol, getFeaturesCol, getPredictionCol)
+    new LightGBMRegressionModel(uid)
+      .setLightGBMBooster(lightGBMBooster)
+      .setFeaturesCol(getFeaturesCol)
+      .setPredictionCol(getPredictionCol)
+      .setLeafPredictionCol(getLeafPredictionCol)
+      .setFeaturesShapCol(getFeaturesShapCol)
   }
 
   def stringFromTrainedModel(model: LightGBMRegressionModel): String = {
@@ -80,57 +83,57 @@ class LightGBMRegressor(override val uid: String)
 
 /** Model produced by [[LightGBMRegressor]]. */
 @InternalWrapper
-class LightGBMRegressionModel(override val uid: String,
-                              override val model: LightGBMBooster,
-                              labelColName: String,
-                              featuresColName: String,
-                              predictionColName: String)
+class LightGBMRegressionModel(override val uid: String)
   extends RegressionModel[Vector, LightGBMRegressionModel]
-    with HasFeatureImportanceGetters
-    with ConstructorWritable[LightGBMRegressionModel] {
+    with LightGBMModelParams
+    with LightGBMModelMethods
+    with LightGBMPredictionParams
+    with ComplexParamsWritable {
 
-  // Update the underlying Spark ML com.microsoft.ml.spark.core.serialize.params
-  // (for proper serialization to work we put them on constructor instead of using copy as in Spark ML)
-  set(labelCol, labelColName)
-  set(featuresCol, featuresColName)
-  set(predictionCol, predictionColName)
-
-  override def predict(features: Vector): Double = {
-    model.score(features, false, false)(0)
+  /**
+    * Adds additional Leaf Index and SHAP columns if specified.
+    *
+    * @param dataset input dataset
+    * @return transformed dataset
+    */
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    var outputData = super.transform(dataset)
+    if (getLeafPredictionCol.nonEmpty) {
+      val predLeafUDF = udf(predictLeaf _)
+      outputData = outputData.withColumn(getLeafPredictionCol,  predLeafUDF(col(getFeaturesCol)))
+    }
+    if (getFeaturesShapCol.nonEmpty) {
+      val featureShapUDF = udf(featuresShap _)
+      outputData = outputData.withColumn(getFeaturesShapCol,  featureShapUDF(col(getFeaturesCol)))
+    }
+    outputData.toDF
   }
 
-  override def copy(extra: ParamMap): LightGBMRegressionModel =
-    new LightGBMRegressionModel(uid, model, labelColName, featuresColName, predictionColName)
+  override def predict(features: Vector): Double = {
+    getModel.score(features, false, false)(0)
+  }
 
-  override val ttag: TypeTag[LightGBMRegressionModel] = typeTag[LightGBMRegressionModel]
-
-  override def objectsToSave: List[Any] = List(uid, model, getLabelCol, getFeaturesCol, getPredictionCol)
+  override def copy(extra: ParamMap): LightGBMRegressionModel = defaultCopy(extra)
 
   def saveNativeModel(filename: String, overwrite: Boolean): Unit = {
     val session = SparkSession.builder().getOrCreate()
-    model.saveNativeModel(session, filename, overwrite)
+    getModel.saveNativeModel(session, filename, overwrite)
   }
-
-  def getModel: LightGBMBooster = this.model
 }
 
-object LightGBMRegressionModel extends ConstructorReadable[LightGBMRegressionModel] {
-  def loadNativeModelFromFile(filename: String, labelColName: String = "label",
-                              featuresColName: String = "features",
-                              predictionColName: String = "prediction"): LightGBMRegressionModel = {
+object LightGBMRegressionModel extends ComplexParamsReadable[LightGBMRegressionModel] {
+  def loadNativeModelFromFile(filename: String): LightGBMRegressionModel = {
     val uid = Identifiable.randomUID("LightGBMRegressor")
     val session = SparkSession.builder().getOrCreate()
     val textRdd = session.read.text(filename)
     val text = textRdd.collect().map { row => row.getString(0) }.mkString("\n")
     val lightGBMBooster = new LightGBMBooster(text)
-    new LightGBMRegressionModel(uid, lightGBMBooster, labelColName, featuresColName, predictionColName)
+    new LightGBMRegressionModel(uid).setLightGBMBooster(lightGBMBooster)
   }
 
-  def loadNativeModelFromString(model: String, labelColName: String = "label",
-                                featuresColName: String = "features",
-                                predictionColName: String = "prediction"): LightGBMRegressionModel = {
+  def loadNativeModelFromString(model: String): LightGBMRegressionModel = {
     val uid = Identifiable.randomUID("LightGBMRegressor")
     val lightGBMBooster = new LightGBMBooster(model)
-    new LightGBMRegressionModel(uid, lightGBMBooster, labelColName, featuresColName, predictionColName)
+    new LightGBMRegressionModel(uid).setLightGBMBooster(lightGBMBooster)
   }
 }

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -99,14 +99,14 @@ trait LightGBMTestUtils extends TestBase {
     assert(model.fit(df).transform(df).collect().length > 0)
   }
 
-  def assertImportanceLengths(fitModel: Model[_] with HasFeatureImportanceGetters, df: DataFrame): Unit = {
+  def assertImportanceLengths(fitModel: Model[_] with LightGBMModelMethods, df: DataFrame): Unit = {
     val splitLength = fitModel.getFeatureImportances("split").length
     val gainLength = fitModel.getFeatureImportances("gain").length
     val featuresLength = df.select(featuresCol).first().getAs[Vector](featuresCol).size
     assert(splitLength == gainLength && splitLength == featuresLength)
   }
 
-  def assertFeatureShapLengths(fitModel: Model[_] with HasFeatureShapGetters, features: Vector, df: DataFrame): Unit = {
+  def assertFeatureShapLengths(fitModel: Model[_] with LightGBMModelMethods, features: Vector, df: DataFrame): Unit = {
     val shapLength = fitModel.getFeatureShaps(features).length
     val featuresLength = df.select(featuresCol).first().getAs[Vector](featuresCol).size
     assert(shapLength == featuresLength + 1)
@@ -603,11 +603,19 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
 
       // Verify can load model from file
       val resultsFromString = LightGBMClassificationModel
-        .loadNativeModelFromString(oldModelString, labelColumnName, featuresCol, rawPredictionColName = rawPredCol)
+        .loadNativeModelFromString(oldModelString)
+        .setFeaturesCol(featuresCol)
+        .setRawPredictionCol(rawPredCol)
+        .setLeafPredictionCol(leafPredCol)
+        .setFeaturesShapCol(featuresShapCol)
         .transform(df)
 
-      val resultsFromFile = LightGBMClassificationModel.
-        loadNativeModelFromFile(modelPath, labelColumnName, featuresCol, rawPredictionColName = rawPredCol)
+      val resultsFromFile = LightGBMClassificationModel
+        .loadNativeModelFromFile(modelPath)
+        .setFeaturesCol(featuresCol)
+        .setRawPredictionCol(rawPredCol)
+        .setLeafPredictionCol(leafPredCol)
+        .setFeaturesShapCol(featuresShapCol)
         .transform(df)
 
       val resultsOriginal = fitModel.transform(df)


### PR DESCRIPTION
unify APIs across LightGBM learner types and add SHAP feature importances to regressor

- Unify the APIs across regressor, ranker and classifier for predicting leaf index, getting global split/gini importances and getting local SHAP feature importances
- Add local SHAP feature importances to regressor
- Update pyspark API

Update:
- made models use ComplexParamsWritable based on PR comments