### PR TITLE
perf: reduce network communication overhead cost on reduce step for LightGBM learners

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
@@ -115,7 +115,7 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
      * number of slots required to run this barrier stage.
      *
      * Hence we still need to estimate the number of workers and repartition even when using
-     * barrier execution, which is unfortunate as repartiton is more expensive than coalesce.
+     * barrier execution, which is unfortunate as repartition is more expensive than coalesce.
      */
     if (getUseBarrierExecutionMode) {
       val numPartitions = df.rdd.getNumPartitions


### PR DESCRIPTION
Reduce the network communication overhead cost in the reduce step for LightGBM learners (LightGBMClassifier, LightGBMRegressor and LightGBMRanker) by only returning the model from one of the nodes (determined by order of nodes initialized).  This is a small optimization that should slightly reduce the overall training time as well as make the code more robust by reducing overall network communication during reduce step.