### PR TITLE
fix: fixed shap values shape for multiclass case and improved pyspark API

### DIFF
--- a/src/main/python/mmlspark/lightgbm/LightGBMClassifier.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMClassifier.py
@@ -12,6 +12,7 @@ from mmlspark.lightgbm._LightGBMClassifier import _LightGBMClassifier
 from mmlspark.lightgbm._LightGBMClassifier import _LightGBMClassificationModel
 from pyspark import SparkContext
 from pyspark.ml.common import inherit_doc
+from pyspark.ml.linalg import SparseVector, DenseVector
 from pyspark.ml.wrapper import JavaParams
 from mmlspark.core.serialize.java_params_patch import *
 
@@ -57,14 +58,17 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         """
         return list(self._java_obj.getFeatureImportances(importance_type))
 
-    def getDenseFeatureShaps(self, vector):
+    def getFeatureShaps(self, vector):
         """
         Get the local shap feature importances.
         """
-        return list(self._java_obj.getFeatureShaps(vector))
-
-    def getSparseFeatureShaps(self, size, indices, values):
-        """
-        Get the local shap feature importances for sparse vectors.
-        """
-        return list(self._java_obj.getSparseFeatureShaps(size, indices, values))
+        if isinstance(vector, DenseVector):
+            dense_values = [float(v) for v in vector]
+            return list(self._java_obj.getDenseFeatureShaps(dense_values))
+        elif isinstance(vector, SparseVector):
+            sparse_size = [float(v) for v in vector.size]
+            sparse_indices = [int(i) for i in vector.indices]
+            sparse_values = [float(v) for v in vector.values]
+            return list(self._java_obj.getSparseFeatureShaps(sparse_size, sparse_indices, sparse_values))
+        else:
+            raise TypeError("Vector argument to getFeatureShaps must be a pyspark.linalg sparse or dense vector type")

--- a/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
@@ -12,6 +12,7 @@ from mmlspark.lightgbm._LightGBMRegressor import _LightGBMRegressor
 from mmlspark.lightgbm._LightGBMRegressor import _LightGBMRegressionModel
 from pyspark import SparkContext
 from pyspark.ml.common import inherit_doc
+from pyspark.ml.linalg import SparseVector, DenseVector
 from pyspark.ml.wrapper import JavaParams
 from mmlspark.core.serialize.java_params_patch import *
 
@@ -57,14 +58,17 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
         """
         return list(self._java_obj.getFeatureImportances(importance_type))
 
-    def getDenseFeatureShaps(self, vector):
+    def getFeatureShaps(self, vector):
         """
         Get the local shap feature importances.
         """
-        return list(self._java_obj.getFeatureShaps(vector))
-
-    def getSparseFeatureShaps(self, size, indices, values):
-        """
-        Get the local shap feature importances for sparse vectors.
-        """
-        return list(self._java_obj.getSparseFeatureShaps(size, indices, values))
+        if isinstance(vector, DenseVector):
+            dense_values = [float(v) for v in vector]
+            return list(self._java_obj.getDenseFeatureShaps(dense_values))
+        elif isinstance(vector, SparseVector):
+            sparse_size = [float(v) for v in vector.size]
+            sparse_indices = [int(i) for i in vector.indices]
+            sparse_values = [float(v) for v in vector.values]
+            return list(self._java_obj.getSparseFeatureShaps(sparse_size, sparse_indices, sparse_values))
+        else:
+            raise TypeError("Vector argument to getFeatureShaps must be a pyspark.linalg sparse or dense vector type")

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
@@ -27,7 +27,7 @@ trait LightGBMModelMethods extends LightGBMModelParams {
   }
 
   /**
-    * Public method to get the dense local SHAP feature importance values for an instance.
+    * Public method for pyspark API to get the dense local SHAP feature importance values for an instance.
     * @param features The local instance or row to compute the SHAP values for.
     * @return The local feature importance values.
     */
@@ -36,7 +36,7 @@ trait LightGBMModelMethods extends LightGBMModelParams {
   }
 
   /**
-    * Public method to get the sparse local SHAP feature importance values for an instance.
+    * Public method for pyspark API to get the sparse local SHAP feature importance values for an instance.
     * @param size: The size of the sparse vector.
     * @param indices: The local instance or row indices to compute the SHAP values for.
     * @param values: The local instance or row values to compute the SHAP values for.


### PR DESCRIPTION
fixed SHAP values shape for multiclass case and improved pyspark API

tagging @ocworld for the multiclass classification SHAP values shape fix