### PR TITLE
feat: Add num tasks override parameter for LightGBM learners

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
@@ -68,6 +68,14 @@ trait LightGBMExecutionParams extends Wrappable {
 
   def getRepartitionByGroupingColumn: Boolean = $(repartitionByGroupingColumn)
   def setRepartitionByGroupingColumn(value: Boolean): this.type = set(repartitionByGroupingColumn, value)
+
+  val numTasks = new IntParam(this, "numTasks",
+    "Advanced parameter to specify the number of tasks.  " +
+      "MMLSpark tries to guess this based on cluster configuration, but this parameter can be used to override.")
+  setDefault(numTasks -> 0)
+
+  def getNumTasks: Int = $(numTasks)
+  def setNumTasks(value: Int): this.type = set(numTasks, value)
 }
 
 /** Defines common parameters across all LightGBM learners related to learning score evolution.

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -303,6 +303,11 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     assertBinaryImprovement(scoredDF1, scoredDF2)
   }
 
+  test("Verify LightGBM Classifier with num tasks parameter") {
+    val numTasks = Array(0, 1, 2)
+    numTasks.foreach(nTasks => assertFitWithoutErrors(baseModel.setNumTasks(nTasks), pimaDF))
+  }
+
   test("Verify LightGBM Classifier with max delta step parameter") {
     // If the max delta step is specified, assert AUC differs (assert parameter works)
     // Note: the final max output of leaves is learning_rate * max_delta_step, so param should reduce the effect


### PR DESCRIPTION
Add num tasks override parameter for LightGBM learners

This parameter will allow users to override the default number of tasks that we try to calculate intelligently on their behalf.

Resolves part of issue:
https://github.com/Azure/mmlspark/issues/879
And issue:
https://github.com/Azure/mmlspark/issues/747