### PR TITLE
fix: categorical parameter regression on dense dataset caused by missing whitespace

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMUtils.scala
@@ -216,7 +216,7 @@ object LightGBMUtils {
     val isRowMajor = 1
     val datasetOutPtr = lightgbmlib.voidpp_handle()
     val datasetParams = s"max_bin=${trainParams.maxBin} is_pre_partition=True " +
-      s"bin_construct_sample_cnt=${trainParams.binSampleCount}" +
+      s"bin_construct_sample_cnt=${trainParams.binSampleCount} " +
       (if (trainParams.categoricalFeatures.isEmpty) ""
       else s"categorical_feature=${trainParams.categoricalFeatures.mkString(",")}")
     val data64bitType = lightgbmlibConstants.C_API_DTYPE_FLOAT64


### PR DESCRIPTION
fix for categorical parameter regression on dense dataset caused by missing whitespace

fixes issue https://github.com/Azure/mmlspark/issues/900