### PR TITLE
fix: Update scalastyle-config.xml to disable the empty regex checker

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -6,7 +6,7 @@
   <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true"><parameters>
     <parameter name="maxLineLength">120</parameter></parameters></check>
   <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
-  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true"><parameters>
+  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="false"><parameters>
     <parameter name="regex">
 
 


### PR DESCRIPTION
This rule would cause IntelliJ IDEA to show errors everywhere. 

See the following screenshot:
![image](https://user-images.githubusercontent.com/3747635/92225898-7285ba00-eed6-11ea-9a74-7f0b27b0c78b.png)
