### PR TITLE
LightGBMRegressor.py : updating imports

### DIFF
--- a/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
@@ -2,9 +2,6 @@
 # Licensed under the MIT License. See LICENSE in project root for information.
 
 import sys
-from pyspark import SQLContext
-from pyspark import SparkContext
-
 if sys.version >= '3':
     basestring = str
 


### PR DESCRIPTION
SparkContext was imported twice. Also SQLContext is outdated, and was not used anyways
... or did I miss something ?