### PR TITLE
fix: Fix processing sparse vector size for getFeatureShaps

### DIFF
--- a/src/main/python/mmlspark/lightgbm/LightGBMClassifier.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMClassifier.py
@@ -66,9 +66,8 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
             dense_values = [float(v) for v in vector]
             return list(self._java_obj.getDenseFeatureShaps(dense_values))
         elif isinstance(vector, SparseVector):
-            sparse_size = [float(v) for v in vector.size]
             sparse_indices = [int(i) for i in vector.indices]
             sparse_values = [float(v) for v in vector.values]
-            return list(self._java_obj.getSparseFeatureShaps(sparse_size, sparse_indices, sparse_values))
+            return list(self._java_obj.getSparseFeatureShaps(vector.size, sparse_indices, sparse_values))
         else:
             raise TypeError("Vector argument to getFeatureShaps must be a pyspark.linalg sparse or dense vector type")

--- a/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMRegressor.py
@@ -66,9 +66,8 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
             dense_values = [float(v) for v in vector]
             return list(self._java_obj.getDenseFeatureShaps(dense_values))
         elif isinstance(vector, SparseVector):
-            sparse_size = [float(v) for v in vector.size]
             sparse_indices = [int(i) for i in vector.indices]
             sparse_values = [float(v) for v in vector.values]
-            return list(self._java_obj.getSparseFeatureShaps(sparse_size, sparse_indices, sparse_values))
+            return list(self._java_obj.getSparseFeatureShaps(vector.size, sparse_indices, sparse_values))
         else:
             raise TypeError("Vector argument to getFeatureShaps must be a pyspark.linalg sparse or dense vector type")


### PR DESCRIPTION
Currently `getFeatureShaps` does not work neither on dense vectors nor sparse ones.
For dense vectors `getDenseFeatureShaps` is not implemented.
But for sparse vectors error comes earlier: `vector.size` is `int` and should be passed further as it is.
This pull request fixes the error with processing field `size` of sparse vectors 