### PR TITLE
azure build pipeline hotfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,8 +240,8 @@ publishPython := {
   publishLocal.value
   packagePythonTask.value
   singleUploadToBlob(
-    join(pythonPackageDir.toString, s"${pythonizedVersion.value}-py2.py3-none-any.whl").toString,
-    version.value + s"/${pythonizedVersion.value}-py2.py3-none-any.whl",
+    join(pythonPackageDir.toString, s"mmlspark-${pythonizedVersion.value}-py2.py3-none-any.whl").toString,
+    version.value + "/" + s"mmlspark-${pythonizedVersion.value}-py2.py3-none-any.whl",
     "pip", s.log)
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,7 @@ publishPython := {
   packagePythonTask.value
   singleUploadToBlob(
     join(pythonPackageDir.toString, s"mmlspark-${pythonizedVersion.value}-py2.py3-none-any.whl").toString,
-    version.value + "/" + s"mmlspark-${pythonizedVersion.value}-py2.py3-none-any.whl",
+    version.value + s"/mmlspark-${pythonizedVersion.value}-py2.py3-none-any.whl",
     "pip", s.log)
 }
 


### PR DESCRIPTION
Hi, the current 'master' branch can't upload 'whl' file to blob storage, the code missed 'mmlspark-'