### PR TITLE
Adds Spark and Open MPI

### DIFF
--- a/tools/docker/demo/Dockerfile
+++ b/tools/docker/demo/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:16.04
 
-ARG SPARK_VERSION=3.0.1
-RUN apt-get -qq update && apt-get -qq -y install curl bzip2 \
+ENV SPARK_VERSION=3.0.2
+ENV HADOOP_VERSION=2.7
+
+RUN apt-get -qq update && apt-get -qq -y install curl bzip2 wget \
     && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local \
     && rm -rf /tmp/miniconda.sh \
@@ -15,8 +17,30 @@ RUN apt-get -qq update && apt-get -qq -y install curl bzip2 \
     && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log \
     && conda clean --all --yes
 
+# Download Spark
+RUN wget https://downloads.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+
+# Install Spark and move it to the folder "/opt/spark"
+RUN tar -xzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+    mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark && \
+    rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz 
+
+ENV SPARK_HOME /opt/spark
 ENV PATH /opt/conda/bin:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+# Open-MPI installation
+ENV OPENMPI_VERSION 3.1.2
+RUN mkdir /tmp/openmpi && \
+    cd /tmp/openmpi && \
+    wget https://download.open-mpi.org/release/open-mpi/v3.1/openmpi-${OPENMPI_VERSION}.tar.gz && \
+    tar zxf openmpi-${OPENMPI_VERSION}.tar.gz && \
+    cd openmpi-${OPENMPI_VERSION} && \
+    ./configure --enable-orterun-prefix-by-default && \
+    make -j $(nproc) all && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/openmpi
 
 RUN conda install jupyter \
     && jupyter-notebook --generate-config \

--- a/tools/docker/minimal/Dockerfile
+++ b/tools/docker/minimal/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:16.04
 
-ARG SPARK_VERSION=3.0.1
-RUN apt-get -qq update && apt-get -qq -y install curl bzip2 \
+ENV SPARK_VERSION=3.0.2
+ENV HADOOP_VERSION=2.7
+
+RUN apt-get -qq update && apt-get -qq -y install curl bzip2 wget\
     && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local \
     && rm -rf /tmp/miniconda.sh \
@@ -13,7 +15,32 @@ RUN apt-get -qq update && apt-get -qq -y install curl bzip2 \
     && apt-get -qq -y autoremove \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log \
-    && conda clean --all --yes
+    && conda clean --all --yes 
 
+# Download Spark
+RUN wget https://downloads.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+
+# # Install Spark and move it to the folder "/opt/spark"
+RUN tar -xzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+    mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark && \
+    rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz 
+
+ENV SPARK_HOME /opt/spark
 ENV PATH /opt/conda/bin:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+ARG MMLSPARK_VERSION
+ENV MMLSPARK_VERSION=${MMLSPARK_VERSION}
+
+# Open-MPI installation
+ENV OPENMPI_VERSION 3.1.2
+RUN mkdir /tmp/openmpi && \
+    cd /tmp/openmpi && \
+    wget https://download.open-mpi.org/release/open-mpi/v3.1/openmpi-${OPENMPI_VERSION}.tar.gz && \
+    tar zxf openmpi-${OPENMPI_VERSION}.tar.gz && \
+    cd openmpi-${OPENMPI_VERSION} && \
+    ./configure --enable-orterun-prefix-by-default && \
+    make -j $(nproc) all && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/openmpi


### PR DESCRIPTION
When installing spark via miniconda the spark home is not set so you cannot run spark in AML.  You will get errors when you try to set the spark context or if you set the framework to pyspark in an AML pipeline step.  This PR installs spark, sets the home, and installs open mpi dependency.