### PR TITLE
fix: reduce lightgbm verbosity to prevent RPC disassociated errors

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
@@ -268,7 +268,7 @@ trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeight
 
   val verbosity = new IntParam(this, "verbosity",
     "Verbosity where lt 0 is Fatal, eq 0 is Error, eq 1 is Info, gt 1 is Debug")
-  setDefault(verbosity -> 1)
+  setDefault(verbosity -> -1)
 
   def getVerbosity: Int = $(verbosity)
   def setVerbosity(value: Int): this.type = set(verbosity, value)

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainUtils.scala
@@ -243,7 +243,6 @@ private object TrainUtils extends Serializable {
       }
 
       try {
-        log.info("LightGBM task calling LGBM_BoosterUpdateOneIter")
         val result = lightgbmlib.LGBM_BoosterUpdateOneIter(boosterPtr.get, isFinishedPtr)
         LightGBMUtils.validate(result, "Booster Update One Iter")
         isFinished = lightgbmlib.intp_value(isFinishedPtr) == 1


### PR DESCRIPTION
A customer reported constantly seeing "Remote RPC Client Disassociated" errors, we traced the issue to logging and the suggested fix here:
https://forums.databricks.com/questions/10616/executorlostfailure-remote-rpc-client-disassociate.html
to reduce logging, seemed to resolve the error.  Hitting the 20MB (that's MB, not GB!) limit in logging seems to cause this error, from the link:


> According to https://docs.databricks.com/jobs.html#jar-job-tips
>
> Job output, such as log output emitted to stdout, is subject to a 20MB size limit. If the total output has a larger size, the run will > be canceled and marked as failed.
