### PR TITLE
chore: update to lightgbm 3.2.110

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= Seq(
   "com.microsoft.cognitiveservices.speech" % "client-sdk" % "1.14.0",
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
   "org.apache.httpcomponents" % "httpmime" % "4.5.6",
-  "com.microsoft.ml.lightgbm" % "lightgbmlib" % "3.2.100",
+  "com.microsoft.ml.lightgbm" % "lightgbmlib" % "3.2.110",
   "com.github.vowpalwabbit" % "vw-jni" % "8.9.1",
   "com.linkedin.isolation-forest" %% "isolation-forest_3.0.0" % "1.0.1",
 ).map(d => d excludeAll (excludes: _*))


### PR DESCRIPTION
update to lightgbm jar 3.2.110 on commit:
https://github.com/microsoft/LightGBM/commit/1e95cb097757996cd82699071c82c205bf2b48a5
commit hash:
1e95cb097757996cd82699071c82c205bf2b48a5
resolves issue:
https://github.com/Azure/mmlspark/issues/986
with lightgbm fix:
https://github.com/microsoft/LightGBM/pull/4185