### PR TITLE
fix: missing returns in new python lightgbm model methods

### DIFF
--- a/src/main/python/mmlspark/lightgbm/LightGBMClassificationModel.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMClassificationModel.py
@@ -70,7 +70,7 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         Returns:
             The best iteration, if early stopping was triggered.
         """
-        self._java_obj.getBoosterBestIteration()
+        return self._java_obj.getBoosterBestIteration()
 
     def getBoosterNumTotalIterations(self):
         """Get the total number of iterations trained.
@@ -78,7 +78,7 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         Returns:
             The total number of iterations trained.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumTotalIterations()
 
     def getBoosterNumTotalModel(self):
         """Get the total number of models trained.
@@ -90,7 +90,7 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         Returns:
             The total number of models.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumTotalModel()
 
     def getBoosterNumFeatures(self):
         """Get the number of features from the booster.
@@ -98,7 +98,7 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         Returns:
             The number of features.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumFeatures()
 
     def getBoosterNumClasses(self):
         """Get the number of classes from the booster.
@@ -106,4 +106,4 @@ class LightGBMClassificationModel(_LightGBMClassificationModel):
         Returns:
             The number of classes.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumClasses()

--- a/src/main/python/mmlspark/lightgbm/LightGBMRankerModel.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMRankerModel.py
@@ -71,7 +71,7 @@ class LightGBMRankerModel(_LightGBMRankerModel):
         Returns:
             The best iteration, if early stopping was triggered.
         """
-        self._java_obj.getBoosterBestIteration()
+        return self._java_obj.getBoosterBestIteration()
 
     def getBoosterNumTotalIterations(self):
         """Get the total number of iterations trained.
@@ -79,7 +79,7 @@ class LightGBMRankerModel(_LightGBMRankerModel):
         Returns:
             The total number of iterations trained.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumTotalIterations()
 
     def getBoosterNumTotalModel(self):
         """Get the total number of models trained.
@@ -87,7 +87,7 @@ class LightGBMRankerModel(_LightGBMRankerModel):
         Returns:
             The total number of models.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumTotalModel()
 
     def getBoosterNumFeatures(self):
         """Get the number of features from the booster.
@@ -95,7 +95,7 @@ class LightGBMRankerModel(_LightGBMRankerModel):
         Returns:
             The number of features.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumFeatures()
 
     def getBoosterNumClasses(self):
         """Get the number of classes from the booster.
@@ -103,4 +103,4 @@ class LightGBMRankerModel(_LightGBMRankerModel):
         Returns:
             The number of classes.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumClasses()

--- a/src/main/python/mmlspark/lightgbm/LightGBMRegressionModel.py
+++ b/src/main/python/mmlspark/lightgbm/LightGBMRegressionModel.py
@@ -69,7 +69,7 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
         Returns:
             The best iteration, if early stopping was triggered.
         """
-        self._java_obj.getBoosterBestIteration()
+        return self._java_obj.getBoosterBestIteration()
 
     def getBoosterNumTotalIterations(self):
         """Get the total number of iterations trained.
@@ -77,7 +77,7 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
         Returns:
             The total number of iterations trained.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumTotalIterations()
 
     def getBoosterNumTotalModel(self):
         """Get the total number of models trained.
@@ -85,7 +85,7 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
         Returns:
             The total number of models.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumTotalModel()
 
     def getBoosterNumFeatures(self):
         """Get the number of features from the booster.
@@ -93,4 +93,4 @@ class LightGBMRegressionModel(_LightGBMRegressionModel):
         Returns:
             The number of features.
         """
-        self._java_obj.getBoosterNumTotalIterations()
+        return self._java_obj.getBoosterNumFeatures()


### PR DESCRIPTION
Missed adding returns to the new model methods for getting booster properties in recently merged PR https://github.com/Azure/mmlspark/pull/1024.  Also noticed some of them were calling the wrong underlying method when testing them out.