### PR TITLE
feat: add chunk size parameter for copying java data to native

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
@@ -49,7 +49,8 @@ class LightGBMClassifier(override val uid: String)
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, getObjective, modelStr,
       getIsUnbalance, getVerbosity, categoricalIndexes, actualNumClasses, getBoostFromAverage,
       getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric,
-      getMetric, getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate)
+      getMetric, getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames,
+      getDelegate, getChunkSize)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
@@ -77,6 +77,15 @@ trait LightGBMExecutionParams extends Wrappable {
 
   def getNumTasks: Int = $(numTasks)
   def setNumTasks(value: Int): this.type = set(numTasks, value)
+
+  val chunkSize = new IntParam(this, "chunkSize",
+    "Advanced parameter to specify the chunk size for copying Java data to native.  " +
+      "If set too high, memory may be wasted, but if set too low, performance may be reduced during data copy." +
+      "If dataset size is known beforehand, set to the number of rows in the dataset.")
+  setDefault(chunkSize -> 10000)
+
+  def getChunkSize: Int = $(chunkSize)
+  def setChunkSize(value: Int): this.type = set(chunkSize, value)
 }
 
 /** Defines common parameters across all LightGBM learners related to learning score evolution.

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
@@ -56,7 +56,7 @@ class LightGBMRanker(override val uid: String)
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr,
       getVerbosity, categoricalIndexes, getBoostingType, getLambdaL1, getLambdaL2, getMaxPosition, getLabelGain,
       getIsProvideTrainingMetric, getMetric, getEvalAt, getMinGainToSplit, getMaxDeltaStep,
-      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate)
+      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getChunkSize)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRankerModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
@@ -63,7 +63,7 @@ class LightGBMRegressor(override val uid: String)
       getEarlyStoppingRound, getImprovementTolerance, getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf,
       numTasks, modelStr, getVerbosity, categoricalIndexes, getBoostFromAverage, getBoostingType, getLambdaL1,
       getLambdaL2, getIsProvideTrainingMetric, getMetric, getMinGainToSplit, getMaxDeltaStep,
-      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate)
+      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getChunkSize)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRegressionModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainParams.scala
@@ -39,6 +39,7 @@ abstract class TrainParams extends Serializable {
   def minDataInLeaf: Int
   def featureNames: Array[String]
   def delegate: Option[LightGBMDelegate]
+  def chunkSize: Int
 
   override def toString: String = {
     // Since passing `isProvideTrainingMetric` to LightGBM as a config parameter won't work,
@@ -71,7 +72,8 @@ case class ClassifierTrainParams(parallelism: String, topK: Int, numIterations: 
                                  boostingType: String, lambdaL1: Double, lambdaL2: Double,
                                  isProvideTrainingMetric: Boolean, metric: String, minGainToSplit: Double,
                                  maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
-                                 featureNames: Array[String], delegate: Option[LightGBMDelegate])
+                                 featureNames: Array[String], delegate: Option[LightGBMDelegate],
+                                 chunkSize: Int)
   extends TrainParams {
   override def toString(): String = {
     val extraStr =
@@ -95,7 +97,8 @@ case class RegressorTrainParams(parallelism: String, topK: Int, numIterations: I
                                 boostingType: String, lambdaL1: Double, lambdaL2: Double,
                                 isProvideTrainingMetric: Boolean, metric: String, minGainToSplit: Double,
                                 maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
-                                featureNames: Array[String], delegate: Option[LightGBMDelegate])
+                                featureNames: Array[String], delegate: Option[LightGBMDelegate],
+                                chunkSize: Int)
   extends TrainParams {
   override def toString(): String = {
     s"alpha=$alpha tweedie_variance_power=$tweedieVariancePower boost_from_average=${boostFromAverage.toString} " +
@@ -116,7 +119,8 @@ case class RankerTrainParams(parallelism: String, topK: Int, numIterations: Int,
                              labelGain: Array[Double], isProvideTrainingMetric: Boolean,
                              metric: String, evalAt: Array[Int], minGainToSplit: Double,
                              maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
-                             featureNames: Array[String], delegate: Option[LightGBMDelegate])
+                             featureNames: Array[String], delegate: Option[LightGBMDelegate],
+                             chunkSize: Int)
   extends TrainParams {
   override def toString(): String = {
     val labelGainStr =


### PR DESCRIPTION
- add chunk size parameter for copying java data to native
- fix minor memory leak
- increase default chunk size from 1000 to 10000, for most real scenarios this is actually still probably more on the smaller side of what it should be set to (the number of rows in the dataset, but we don't want to do a count beforehand since it is expensive)