### PR TITLE
feat: add several parameters related to dart boosting type

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
@@ -180,6 +180,10 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
     }
   }
 
+  protected def getDartParams(): DartModeParams = {
+    DartModeParams(getDropRate, getMaxDrop, getSkipDrop, getXGBoostDartMode, getUniformDrop)
+  }
+
   /**
     * Inner train method for LightGBM learners.  Calculates the number of workers,
     * creates a driver thread, and runs mapPartitions on the dataset.

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
@@ -50,7 +50,7 @@ class LightGBMClassifier(override val uid: String)
       getIsUnbalance, getVerbosity, categoricalIndexes, actualNumClasses, getBoostFromAverage,
       getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric,
       getMetric, getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames,
-      getDelegate, getChunkSize)
+      getDelegate, getChunkSize, getDartParams())
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMParams.scala
@@ -121,6 +121,45 @@ trait LightGBMBinParams extends Wrappable {
   def setBinSampleCount(value: Int): this.type = set(binSampleCount, value)
 }
 
+/** Defines parameters for dart mode across all LightGBM learners.
+ */
+trait LightGBMDartParams extends Wrappable {
+  val dropRate = new DoubleParam(this, "dropRate",
+    "Dropout rate: a fraction of previous trees to drop during the dropout")
+  setDefault(dropRate -> 0.1)
+
+  def getDropRate: Double = $(dropRate)
+  def setDropRate(value: Double): this.type = set(dropRate, value)
+
+  val maxDrop = new IntParam(this, "maxDrop",
+    "Max number of dropped trees during one boosting iteration")
+  setDefault(maxDrop -> 50)
+
+  def getMaxDrop: Int = $(maxDrop)
+  def setMaxDrop(value: Int): this.type = set(maxDrop, value)
+
+  val skipDrop = new DoubleParam(this, "skipDrop",
+    "Probability of skipping the dropout procedure during a boosting iteration")
+  setDefault(skipDrop -> 0.5)
+
+  def getSkipDrop: Double = $(skipDrop)
+  def setSkipDrop(value: Double): this.type = set(skipDrop, value)
+
+  val xgboostDartMode = new BooleanParam(this, "xgboostDartMode",
+    "Set this to true to use xgboost dart mode")
+  setDefault(xgboostDartMode -> false)
+
+  def getXGBoostDartMode: Boolean = $(xgboostDartMode)
+  def setXGBoostDartMode(value: Boolean): this.type = set(xgboostDartMode, value)
+
+  val uniformDrop = new BooleanParam(this, "uniformDrop",
+    "Set this to true to use uniform drop in dart mode")
+  setDefault(uniformDrop -> false)
+
+  def getUniformDrop: Boolean = $(uniformDrop)
+  def setUniformDrop(value: Boolean): this.type = set(uniformDrop, value)
+}
+
 /** Defines parameters for slots across all LightGBM learners.
  */
 trait LightGBMSlotParams extends Wrappable {
@@ -231,7 +270,7 @@ trait LightGBMModelParams extends Wrappable {
 trait LightGBMParams extends Wrappable with DefaultParamsWritable with HasWeightCol
   with HasValidationIndicatorCol with HasInitScoreCol with LightGBMExecutionParams
   with LightGBMSlotParams with LightGBMFractionParams with LightGBMBinParams with LightGBMLearnerParams
-  with LightGBMPredictionParams {
+  with LightGBMDartParams with LightGBMPredictionParams {
   val numIterations = new IntParam(this, "numIterations",
     "Number of iterations, LightGBM constructs num_class * num_iterations trees")
   setDefault(numIterations->100)

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
@@ -56,7 +56,7 @@ class LightGBMRanker(override val uid: String)
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr,
       getVerbosity, categoricalIndexes, getBoostingType, getLambdaL1, getLambdaL2, getMaxPosition, getLabelGain,
       getIsProvideTrainingMetric, getMetric, getEvalAt, getMinGainToSplit, getMaxDeltaStep,
-      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getChunkSize)
+      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getChunkSize, getDartParams())
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRankerModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
@@ -63,7 +63,7 @@ class LightGBMRegressor(override val uid: String)
       getEarlyStoppingRound, getImprovementTolerance, getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf,
       numTasks, modelStr, getVerbosity, categoricalIndexes, getBoostFromAverage, getBoostingType, getLambdaL1,
       getLambdaL2, getIsProvideTrainingMetric, getMetric, getMinGainToSplit, getMaxDeltaStep,
-      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getChunkSize)
+      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getChunkSize, getDartParams())
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRegressionModel = {

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -317,6 +317,20 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     assertBinaryImprovement(scoredDF1, scoredDF2)
   }
 
+  test("Verify LightGBM Classifier with dart mode parameters") {
+    // Assert the dart parameters work without failing and setting them to tuned values improves performance
+    val Array(train, test) = pimaDF.randomSplit(Array(0.8, 0.2), seed)
+    val scoredDF1 = baseModel.setBoostingType("dart").fit(train).transform(test)
+    val scoredDF2 = baseModel.setBoostingType("dart")
+      .setXGBoostDartMode(true)
+      .setDropRate(0.6)
+      .setMaxDrop(60)
+      .setSkipDrop(0.6)
+      .setUniformDrop(true)
+      .fit(train).transform(test)
+    assertBinaryImprovement(scoredDF1, scoredDF2)
+  }
+
   test("Verify LightGBM Classifier with num tasks parameter") {
     val numTasks = Array(0, 1, 2)
     numTasks.foreach(nTasks => assertFitWithoutErrors(baseModel.setNumTasks(nTasks), pimaDF))


### PR DESCRIPTION
Add several parameters for dart mode as requested by two internal data scientists:

-  ``drop_rate``, default = ``0.1``, type = double, aliases: ``rate_drop``, constraints: ``0.0 <= drop_rate <= 1.0``

   -  used only in ``dart``

   -  dropout rate: a fraction of previous trees to drop during the dropout

-  ``max_drop``, default = ``50``, type = int

   -  used only in ``dart``

   -  max number of dropped trees during one boosting iteration

   -  ``<=0`` means no limit

-  ``skip_drop``, default = ``0.5``, type = double, constraints: ``0.0 <= skip_drop <= 1.0``

   -  used only in ``dart``

   -  probability of skipping the dropout procedure during a boosting iteration

-  ``xgboost_dart_mode``, default = ``false``, type = bool

   -  used only in ``dart``

   -  set this to ``true``, if you want to use xgboost dart mode

-  ``uniform_drop``, default = ``false``, type = bool

   -  used only in ``dart``

   -  set this to ``true``, if you want to use uniform drop