### PR TITLE
feat: add custom objective function to lightgbm learners

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -12,7 +12,7 @@
     <parameter name="header">^// Copyright \(C\) Microsoft Corporation\. All rights reserved\.
 // Licensed under the MIT License\. See LICENSE in project root for information\.
 
-package (?:com\.microsoft\.ml\.spark|org\.apache\.spark|com\.microsoft\.CNTK|com\.microsoft\.ml\.lightgbm)[.
+package (?:com\.microsoft\.ml\.spark|org\.apache\.spark|com\.microsoft\.CNTK|com\.microsoft\.ml\.lightgbm|com\.microsoft\.lightgbm)[.
 ]</parameter>
     <parameter name="regex">true</parameter></parameters></check>
   <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>

--- a/scalastyle-test-config.xml
+++ b/scalastyle-test-config.xml
@@ -6,13 +6,13 @@
   <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true"><parameters>
     <parameter name="maxLineLength">120</parameter></parameters></check>
   <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="true"><parameters>
+  <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="true"><parameters>
     <parameter name="regex">.{33}</parameter></parameters></check>
   <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true"><parameters>
     <parameter name="header">^// Copyright \(C\) Microsoft Corporation\. All rights reserved\.
 // Licensed under the MIT License\. See LICENSE in project root for information\.
 
-package (?:com\.microsoft\.ml\.spark|org\.apache\.spark|com\.microsoft\.CNTK|com\.microsoft\.ml\.lightgbm)[.
+package (?:com\.microsoft\.ml\.spark|org\.apache\.spark|com\.microsoft\.CNTK|com\.microsoft\.ml\.lightgbm|com\.microsoft\.lightgbm)[.
 ]</parameter>
     <parameter name="regex">true</parameter></parameters></check>
   <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>

--- a/src/main/scala/com/microsoft/lightgbm/SWIG.scala
+++ b/src/main/scala/com/microsoft/lightgbm/SWIG.scala
@@ -1,0 +1,13 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.lightgbm
+
+import com.microsoft.ml.lightgbm.SWIGTYPE_p_void
+
+class SwigPtrWrapper(val value: SWIGTYPE_p_void) extends SWIGTYPE_p_void {
+  /** Helper function to get the underlying pointer address from the SWIG pointer object.
+    * @return The underlying pointer address as a long.
+    */
+  def getCPtrValue(): Long = SWIGTYPE_p_void.getCPtr(value)
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMBase.scala
@@ -4,6 +4,9 @@
 package com.microsoft.ml.spark.lightgbm
 
 import com.microsoft.ml.spark.core.utils.ClusterUtil
+import com.microsoft.ml.spark.lightgbm.booster.LightGBMBooster
+import com.microsoft.ml.spark.lightgbm.params.{DartModeParams, ExecutionParams, LightGBMParams,
+  ObjectiveParams, TrainParams}
 import com.microsoft.ml.spark.logging.BasicLogging
 import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
@@ -180,12 +183,28 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
     }
   }
 
+  /**
+    * Constructs the DartModeParams
+    * @return DartModeParams object containing parameters related to dart mode.
+    */
   protected def getDartParams(): DartModeParams = {
     DartModeParams(getDropRate, getMaxDrop, getSkipDrop, getXGBoostDartMode, getUniformDrop)
   }
 
+  /**
+    * Constructs the ExecutionParams.
+    * @return ExecutionParams object containing parameters related to LightGBM execution.
+    */
   protected def getExecutionParams(): ExecutionParams = {
     ExecutionParams(getChunkSize, getMatrixType)
+  }
+
+  /**
+    * Constructs the ObjectiveParams.
+    * @return ObjectiveParams object containing parameters related to the objective function.
+    */
+  protected def getObjectiveParams(): ObjectiveParams = {
+    ObjectiveParams(getObjective, if (isDefined(fobj)) Some(getFObj) else None)
   }
 
   /**

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMDelegate.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMDelegate.scala
@@ -3,7 +3,8 @@
 
 package com.microsoft.ml.spark.lightgbm
 
-import com.microsoft.ml.lightgbm.SWIGTYPE_p_void
+import com.microsoft.ml.spark.lightgbm.booster.LightGBMBooster
+import com.microsoft.ml.spark.lightgbm.params.TrainParams
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
 import org.slf4j.Logger
@@ -40,12 +41,12 @@ trait LightGBMDelegate extends Serializable {
   }
 
   def beforeTrainIteration(batchIndex: Int, partitionId: Int, curIters: Int, log: Logger,
-                           trainParams: TrainParams, boosterPtr: Option[SWIGTYPE_p_void], hasValid: Boolean): Unit = {
+                           trainParams: TrainParams, booster: LightGBMBooster, hasValid: Boolean): Unit = {
     // override this function and write code
   }
 
   def afterTrainIteration(batchIndex: Int, partitionId: Int, curIters: Int, log: Logger,
-                          trainParams: TrainParams, boosterPtr: Option[SWIGTYPE_p_void], hasValid: Boolean,
+                          trainParams: TrainParams, booster: LightGBMBooster, hasValid: Boolean,
                           isFinished: Boolean,
                           trainEvalResults: Option[Map[String, Double]],
                           validEvalResults: Option[Map[String, Double]]): Unit = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
@@ -3,6 +3,7 @@
 
 package com.microsoft.ml.spark.lightgbm
 
+import com.microsoft.ml.spark.lightgbm.params.LightGBMModelParams
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
@@ -3,6 +3,9 @@
 
 package com.microsoft.ml.spark.lightgbm
 
+import com.microsoft.ml.spark.lightgbm.booster.LightGBMBooster
+import com.microsoft.ml.spark.lightgbm.params.{LightGBMModelParams, LightGBMPredictionParams,
+  RegressorTrainParams, TrainParams}
 import com.microsoft.ml.spark.logging.BasicLogging
 import org.apache.spark.ml.{BaseRegressor, ComplexParamsReadable, ComplexParamsWritable}
 import org.apache.spark.ml.param._
@@ -58,12 +61,12 @@ class LightGBMRegressor(override val uid: String)
   def getTrainParams(numTasks: Int, categoricalIndexes: Array[Int], dataset: Dataset[_]): TrainParams = {
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
     RegressorTrainParams(getParallelism, getTopK, getNumIterations, getLearningRate, getNumLeaves,
-      getObjective, getAlpha, getTweedieVariancePower, getMaxBin, getBinSampleCount,
-      getBaggingFraction, getPosBaggingFraction, getNegBaggingFraction, getBaggingFreq, getBaggingSeed,
-      getEarlyStoppingRound, getImprovementTolerance, getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf,
-      numTasks, modelStr, getVerbosity, categoricalIndexes, getBoostFromAverage, getBoostingType, getLambdaL1,
-      getLambdaL2, getIsProvideTrainingMetric, getMetric, getMinGainToSplit, getMaxDeltaStep,
-      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getDartParams(), getExecutionParams())
+      getAlpha, getTweedieVariancePower, getMaxBin, getBinSampleCount, getBaggingFraction, getPosBaggingFraction,
+      getNegBaggingFraction, getBaggingFreq, getBaggingSeed, getEarlyStoppingRound, getImprovementTolerance,
+      getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr, getVerbosity, categoricalIndexes,
+      getBoostFromAverage, getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric, getMetric,
+      getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate,
+      getDartParams(), getExecutionParams(), getObjectiveParams())
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRegressionModel = {
@@ -77,7 +80,7 @@ class LightGBMRegressor(override val uid: String)
   }
 
   def stringFromTrainedModel(model: LightGBMRegressionModel): String = {
-    model.getModel.model
+    model.getModel.modelStr.get
   }
 
   override def copy(extra: ParamMap): LightGBMRegressor = defaultCopy(extra)
@@ -134,7 +137,7 @@ class LightGBMRegressionModel(override val uid: String)
 
 object LightGBMRegressionModel extends ComplexParamsReadable[LightGBMRegressionModel] {
   def loadNativeModelFromFile(filename: String): LightGBMRegressionModel = {
-    val uid = Identifiable.randomUID("LightGBMRegressor")
+    val uid = Identifiable.randomUID("LightGBMRegressionModel")
     val session = SparkSession.builder().getOrCreate()
     val textRdd = session.read.text(filename)
     val text = textRdd.collect().map { row => row.getString(0) }.mkString("\n")
@@ -143,7 +146,7 @@ object LightGBMRegressionModel extends ComplexParamsReadable[LightGBMRegressionM
   }
 
   def loadNativeModelFromString(model: String): LightGBMRegressionModel = {
-    val uid = Identifiable.randomUID("LightGBMRegressor")
+    val uid = Identifiable.randomUID("LightGBMRegressionModel")
     val lightGBMBooster = new LightGBMBooster(model)
     new LightGBMRegressionModel(uid).setLightGBMBooster(lightGBMBooster)
   }

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMUtils.scala
@@ -11,6 +11,8 @@ import com.microsoft.ml.lightgbm._
 import com.microsoft.ml.spark.core.env.NativeLoader
 import com.microsoft.ml.spark.core.utils.ClusterUtil
 import com.microsoft.ml.spark.featurize.{Featurize, FeaturizeUtilities}
+import com.microsoft.ml.spark.lightgbm.dataset.LightGBMDataset
+import com.microsoft.ml.spark.lightgbm.params.TrainParams
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.attribute._
@@ -245,7 +247,7 @@ object LightGBMUtils {
       LightGBMUtils.validate(lightgbmlib.LGBM_DatasetCreateFromMats(featuresArray.get_chunks_count().toInt,
         featuresArray.data_as_void(), data64bitType,
         numRowsForChunks, numCols,
-        isRowMajor, datasetParams, referenceDataset.map(_.dataset).orNull, datasetOutPtr),
+        isRowMajor, datasetParams, referenceDataset.map(_.datasetPtr).orNull, datasetOutPtr),
         "Dataset create")
     } finally {
       featuresArray.release()
@@ -275,7 +277,7 @@ object LightGBMUtils {
     LightGBMUtils.validate(lightgbmlib.LGBM_DatasetCreateFromCSRSpark(
       sparseRows.asInstanceOf[Array[Object]],
       sparseRows.length,
-      numCols, datasetParams, referenceDataset.map(_.dataset).orNull,
+      numCols, datasetParams, referenceDataset.map(_.datasetPtr).orNull,
       datasetOutPtr),
       "Dataset create")
     val dataset = new LightGBMDataset(lightgbmlib.voidpp_value(datasetOutPtr))

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/params/FObjParam.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/params/FObjParam.scala
@@ -1,0 +1,19 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm.params
+
+import com.microsoft.ml.spark.core.serialize.ComplexParam
+import org.apache.spark.ml.param.Params
+
+/** Param for FObjTrait.  Needed as spark has explicit params for many different
+  * types but not FObjTrait.
+  */
+class FObjParam(parent: Params, name: String, doc: String,
+                isValid: FObjTrait => Boolean)
+
+  extends ComplexParam[FObjTrait](parent, name, doc, isValid) {
+
+  def this(parent: Params, name: String, doc: String) =
+    this(parent, name, doc, {_ => true})
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/params/FObjTrait.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/params/FObjTrait.scala
@@ -1,0 +1,17 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm.params
+
+import com.microsoft.ml.spark.lightgbm.dataset.LightGBMDataset
+
+trait FObjTrait extends Serializable {
+  /**
+    * User defined objective function, returns gradient and second order gradient
+    *
+    * @param predictions untransformed margin predicts
+    * @param trainingData training data
+    * @return List with two float array, correspond to grad and hess
+    */
+  def getGradient(predictions: Array[Array[Double]], trainingData: LightGBMDataset): (Array[Float], Array[Float])
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/params/LightGBMBoosterParam.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/params/LightGBMBoosterParam.scala
@@ -1,9 +1,10 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in project root for information.
 
-package com.microsoft.ml.spark.lightgbm
+package com.microsoft.ml.spark.lightgbm.params
 
 import com.microsoft.ml.spark.core.serialize.ComplexParam
+import com.microsoft.ml.spark.lightgbm.booster.LightGBMBooster
 import org.apache.spark.ml.param.Params
 
 /** Custom ComplexParam for LightGBMBooster, to make it settable on the LightGBM models.

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/params/TrainParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/params/TrainParams.scala
@@ -1,7 +1,9 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in project root for information.
 
-package com.microsoft.ml.spark.lightgbm
+package com.microsoft.ml.spark.lightgbm.params
+
+import com.microsoft.ml.spark.lightgbm.{LightGBMConstants, LightGBMDelegate}
 
 /** Defines the common Booster parameters passed to the LightGBM learners.
   */
@@ -24,7 +26,6 @@ abstract class TrainParams extends Serializable {
   def maxDepth: Int
   def minSumHessianInLeaf: Double
   def numMachines: Int
-  def objective: String
   def modelString: Option[String]
   def verbosity: Int
   def categoricalFeatures: Array[Int]
@@ -41,6 +42,7 @@ abstract class TrainParams extends Serializable {
   def delegate: Option[LightGBMDelegate]
   def dartModeParams: DartModeParams
   def executionParams: ExecutionParams
+  def objectiveParams: ObjectiveParams
 
   override def toString: String = {
     // Since passing `isProvideTrainingMetric` to LightGBM as a config parameter won't work,
@@ -51,9 +53,9 @@ abstract class TrainParams extends Serializable {
       s"neg_bagging_fraction=$negBaggingFraction bagging_freq=$baggingFreq " +
       s"bagging_seed=$baggingSeed early_stopping_round=$earlyStoppingRound " +
       s"feature_fraction=$featureFraction max_depth=$maxDepth min_sum_hessian_in_leaf=$minSumHessianInLeaf " +
-      s"num_machines=$numMachines objective=$objective verbosity=$verbosity " +
+      s"num_machines=$numMachines verbosity=$verbosity " +
       s"lambda_l1=$lambdaL1 lambda_l2=$lambdaL2 metric=$metric min_gain_to_split=$minGainToSplit " +
-      s"max_delta_step=$maxDeltaStep min_data_in_leaf=$minDataInLeaf " +
+      s"max_delta_step=$maxDeltaStep min_data_in_leaf=$minDataInLeaf ${objectiveParams.toString()} " +
       (if (categoricalFeatures.isEmpty) "" else s"categorical_feature=${categoricalFeatures.mkString(",")} ") +
       (if (maxBinByFeature.isEmpty) "" else s"max_bin_by_feature=${maxBinByFeature.mkString(",")} ") +
       (if (boostingType == "dart") s"${dartModeParams.toString()}" else "")
@@ -68,18 +70,18 @@ case class ClassifierTrainParams(parallelism: String, topK: Int, numIterations: 
                                  baggingFreq: Int, baggingSeed: Int, earlyStoppingRound: Int,
                                  improvementTolerance: Double, featureFraction: Double,
                                  maxDepth: Int, minSumHessianInLeaf: Double,
-                                 numMachines: Int, objective: String, modelString: Option[String],
-                                 isUnbalance: Boolean, verbosity: Int, categoricalFeatures: Array[Int],
-                                 numClass: Int, boostFromAverage: Boolean,
-                                 boostingType: String, lambdaL1: Double, lambdaL2: Double,
+                                 numMachines: Int, modelString: Option[String], isUnbalance: Boolean,
+                                 verbosity: Int, categoricalFeatures: Array[Int], numClass: Int,
+                                 boostFromAverage: Boolean, boostingType: String, lambdaL1: Double, lambdaL2: Double,
                                  isProvideTrainingMetric: Boolean, metric: String, minGainToSplit: Double,
                                  maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
                                  featureNames: Array[String], delegate: Option[LightGBMDelegate],
-                                 dartModeParams: DartModeParams, executionParams: ExecutionParams)
+                                 dartModeParams: DartModeParams, executionParams: ExecutionParams,
+                                 objectiveParams: ObjectiveParams)
   extends TrainParams {
   override def toString(): String = {
     val extraStr =
-      if (objective != LightGBMConstants.BinaryObjective) s"num_class=$numClass"
+      if (objectiveParams.objective != LightGBMConstants.BinaryObjective) s"num_class=$numClass"
       else s"is_unbalance=${isUnbalance.toString}"
     s"metric=$metric boost_from_average=${boostFromAverage.toString} ${super.toString()} $extraStr"
   }
@@ -88,11 +90,10 @@ case class ClassifierTrainParams(parallelism: String, topK: Int, numIterations: 
 /** Defines the Booster parameters passed to the LightGBM regressor.
   */
 case class RegressorTrainParams(parallelism: String, topK: Int, numIterations: Int, learningRate: Double,
-                                numLeaves: Int, objective: String, alpha: Double,
-                                tweedieVariancePower: Double, maxBin: Int, binSampleCount: Int,
-                                baggingFraction: Double, posBaggingFraction: Double, negBaggingFraction: Double,
-                                baggingFreq: Int, baggingSeed: Int, earlyStoppingRound: Int,
-                                improvementTolerance: Double, featureFraction: Double,
+                                numLeaves: Int, alpha: Double, tweedieVariancePower: Double, maxBin: Int,
+                                binSampleCount: Int, baggingFraction: Double, posBaggingFraction: Double,
+                                negBaggingFraction: Double, baggingFreq: Int, baggingSeed: Int,
+                                earlyStoppingRound: Int, improvementTolerance: Double, featureFraction: Double,
                                 maxDepth: Int, minSumHessianInLeaf: Double, numMachines: Int,
                                 modelString: Option[String], verbosity: Int,
                                 categoricalFeatures: Array[Int], boostFromAverage: Boolean,
@@ -100,7 +101,8 @@ case class RegressorTrainParams(parallelism: String, topK: Int, numIterations: I
                                 isProvideTrainingMetric: Boolean, metric: String, minGainToSplit: Double,
                                 maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
                                 featureNames: Array[String], delegate: Option[LightGBMDelegate],
-                                dartModeParams: DartModeParams, executionParams: ExecutionParams)
+                                dartModeParams: DartModeParams, executionParams: ExecutionParams,
+                                objectiveParams: ObjectiveParams)
   extends TrainParams {
   override def toString(): String = {
     s"alpha=$alpha tweedie_variance_power=$tweedieVariancePower boost_from_average=${boostFromAverage.toString} " +
@@ -111,9 +113,9 @@ case class RegressorTrainParams(parallelism: String, topK: Int, numIterations: I
 /** Defines the Booster parameters passed to the LightGBM ranker.
   */
 case class RankerTrainParams(parallelism: String, topK: Int, numIterations: Int, learningRate: Double,
-                             numLeaves: Int, objective: String, maxBin: Int, binSampleCount: Int,
-                             baggingFraction: Double, posBaggingFraction: Double, negBaggingFraction: Double,
-                             baggingFreq: Int, baggingSeed: Int, earlyStoppingRound: Int, improvementTolerance: Double,
+                             numLeaves: Int, maxBin: Int, binSampleCount: Int, baggingFraction: Double,
+                             posBaggingFraction: Double, negBaggingFraction: Double, baggingFreq: Int,
+                             baggingSeed: Int, earlyStoppingRound: Int, improvementTolerance: Double,
                              featureFraction: Double, maxDepth: Int, minSumHessianInLeaf: Double, numMachines: Int,
                              modelString: Option[String], verbosity: Int,
                              categoricalFeatures: Array[Int], boostingType: String,
@@ -122,7 +124,8 @@ case class RankerTrainParams(parallelism: String, topK: Int, numIterations: Int,
                              metric: String, evalAt: Array[Int], minGainToSplit: Double,
                              maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
                              featureNames: Array[String], delegate: Option[LightGBMDelegate],
-                             dartModeParams: DartModeParams, executionParams: ExecutionParams)
+                             dartModeParams: DartModeParams, executionParams: ExecutionParams,
+                             objectiveParams: ObjectiveParams)
   extends TrainParams {
   override def toString(): String = {
     val labelGainStr =
@@ -143,4 +146,28 @@ case class DartModeParams(dropRate: Double, maxDrop: Int, skipDrop: Double,
   }
 }
 
+/** Defines parameters related to lightgbm execution in spark.
+  *
+  * @param chunkSize Advanced parameter to specify the chunk size for copying Java data to native.
+  * @param matrixType Advanced parameter to specify whether the native lightgbm matrix
+  *                   constructed should be sparse or dense.
+  */
 case class ExecutionParams(chunkSize: Int, matrixType: String) extends Serializable
+
+/** Defines parameters related to the lightgbm objective function.
+  *
+  * @param objective The Objective. For regression applications, this can be:
+  *                  regression_l2, regression_l1, huber, fair, poisson, quantile, mape, gamma or tweedie.
+  *                  For classification applications, this can be: binary, multiclass, or multiclassova.
+  * @param fobj      Customized objective function.
+  *                  Should accept two parameters: preds, train_data, and return (grad, hess).
+  */
+case class ObjectiveParams(objective: String, fobj: Option[FObjTrait]) extends Serializable {
+  override def toString(): String = {
+    if (fobj.isEmpty) {
+      s"objective=$objective "
+    } else {
+      ""
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/swig/SwigUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/swig/SwigUtils.scala
@@ -1,0 +1,19 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm.swig
+
+import com.microsoft.ml.lightgbm.{SWIGTYPE_p_float, lightgbmlib}
+
+object SwigUtils extends Serializable {
+  /** Converts a Java float array to a native C++ array using SWIG.
+    * @param array The Java float Array to convert.
+    * @return The SWIG wrapper around the native array.
+    */
+  def floatArrayToNative(array: Array[Float]): SWIGTYPE_p_float = {
+    val colArray = lightgbmlib.new_floatArray(array.length)
+    array.zipWithIndex.foreach(ri =>
+      lightgbmlib.floatArray_setitem(colArray, ri._2.toLong, ri._1.toFloat))
+    colArray
+  }
+}

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -12,6 +12,8 @@ import com.microsoft.ml.spark.core.test.benchmarks.{Benchmarks, DatasetUtils}
 import com.microsoft.ml.spark.core.test.fuzzing.{EstimatorFuzzing, TestObject}
 import com.microsoft.ml.spark.featurize.ValueIndexer
 import com.microsoft.ml.spark.lightgbm._
+import com.microsoft.ml.spark.lightgbm.dataset.LightGBMDataset
+import com.microsoft.ml.spark.lightgbm.params.{FObjTrait, TrainParams}
 import com.microsoft.ml.spark.stages.{MultiColumnAdapter, SPConstants, StratifiedRepartition}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.TaskContext
@@ -25,6 +27,8 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.functions._
 import org.slf4j.Logger
+
+import scala.math.exp
 
 @SerialVersionUID(100L)
 class TrainDelegate extends LightGBMDelegate {
@@ -267,7 +271,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     assert(fitModel != null)
 
     // Validate lambda parameters set on model
-    val modelStr = fitModel.bestModel.asInstanceOf[LightGBMClassificationModel].getModel.model
+    val modelStr = fitModel.bestModel.asInstanceOf[LightGBMClassificationModel].getModel.modelStr.get
     assert(modelStr.contains("[lambda_l1: 0.1]") || modelStr.contains("[lambda_l1: 0.5]"))
     assert(modelStr.contains("[lambda_l2: 0.1]") || modelStr.contains("[lambda_l2: 0.5]"))
   }
@@ -310,6 +314,35 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     assertMulticlassImprovement(scoredDF1, scoredDF2)
   }
 
+  test("Verify LightGBM Classifier with custom loss function") {
+    class LogLikelihood extends FObjTrait {
+      override def getGradient(predictions: Array[Array[Double]],
+                               trainingData: LightGBMDataset): (Array[Float], Array[Float]) = {
+        // Get the labels
+        val labels = trainingData.getLabel()
+        val probabilities = predictions.map(rowPrediction =>
+          rowPrediction.map(prediction => 1.0 / (1.0 + exp(-prediction))))
+        // Compute gradient and hessian
+        val grad =  probabilities.zip(labels).map {
+          case (prob: Array[Double], label: Float) => (prob(0) - label).toFloat
+        }
+        val hess = probabilities.map(probabilityArray => (probabilityArray(0) * (1 - probabilityArray(0))).toFloat)
+        (grad, hess)
+      }
+    }
+    val scoredDF1 = baseModel
+      .fit(pimaDF)
+      .transform(pimaDF)
+    // Note: run for more iterations than non-custom objective to prevent flakiness
+    // Note we intentionally overfit here on the training data and don't do a split
+    val scoredDF2 = baseModel
+      .setFObj(new LogLikelihood())
+      .setNumIterations(300)
+      .fit(pimaDF)
+      .transform(pimaDF)
+    assertBinaryImprovement(scoredDF1, scoredDF2)
+  }
+
   test("Verify LightGBM Classifier with min gain to split parameter") {
     // If the min gain to split is too high, assert AUC lower for training data (assert parameter works)
     val scoredDF1 = baseModel.setMinGainToSplit(99999).fit(pimaDF).transform(pimaDF)
@@ -320,11 +353,12 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
   test("Verify LightGBM Classifier with dart mode parameters") {
     // Assert the dart parameters work without failing and setting them to tuned values improves performance
     val Array(train, test) = pimaDF.randomSplit(Array(0.8, 0.2), seed)
-    val scoredDF1 = baseModel.setBoostingType("dart").
-      setMaxDrop(1)
-      .setSkipDrop(0.9)
+    val scoredDF1 = baseModel.setBoostingType("dart")
+      .setNumIterations(100)
+      .setSkipDrop(1.0)
       .fit(train).transform(test)
     val scoredDF2 = baseModel.setBoostingType("dart")
+      .setNumIterations(100)
       .setXGBoostDartMode(true)
       .setDropRate(0.6)
       .setMaxDrop(60)
@@ -436,7 +470,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     val untrainedModel = baseModel.setCategoricalSlotNames(categoricalSlotNames)
     val model = untrainedModel.fit(train)
     // Verify categorical features used in some tree in the model
-    assert(model.getModel.model.contains("num_cat=1"))
+    assert(model.getModel.modelStr.get.contains("num_cat=1"))
     val metric = binaryEvaluator
       .evaluate(model.transform(test))
     // Verify we get good result
@@ -454,7 +488,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     val model = untrainedModel.fit(train)
     // Verify non-zero categorical features used in some tree in the model
     val numCats = Range(1, 5).map(cat => s"num_cat=${cat}")
-    assert(numCats.exists(model.getModel.model.contains(_)))
+    assert(numCats.exists(model.getModel.modelStr.get.contains(_)))
     val metric = binaryEvaluator
       .evaluate(model.transform(test))
     // Verify we get good result
@@ -473,7 +507,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     val model = untrainedModel.fit(train)
 
     // Verify updating learning_rate
-    assert(model.getModel.model.contains("learning_rate: 0.005"))
+    assert(model.getModel.modelStr.get.contains("learning_rate: 0.005"))
   }
 
   test("Verify LightGBM Classifier leaf prediction") {
@@ -555,7 +589,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     val model = untrainedModel.fit(newDf)
 
     // Verify the Age_years column that is renamed  used in some tree in the model
-    assert(model.getModel.model.contains("Age_years"))
+    assert(model.getModel.modelStr.get.contains("Age_years"))
   }
 
   test("Verify LightGBM Classifier won't get stuck on empty partitions") {
@@ -691,7 +725,7 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
       fitModel.saveNativeModel(modelPath, overwrite = true)
       assert(Files.exists(Paths.get(modelPath)), true)
 
-      val oldModelString = fitModel.getModel.model
+      val oldModelString = fitModel.getModel.modelStr.get
       // Verify model string contains some feature
       colsToVerify.foreach(col => oldModelString.contains(col))
 

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split2/VerifyLightGBMRegressor.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split2/VerifyLightGBMRegressor.scala
@@ -79,7 +79,7 @@ class VerifyLightGBMRegressor extends Benchmarks
     assert(fitModel != null)
 
     // Validate lambda parameters set on model
-    val modelStr = fitModel.bestModel.asInstanceOf[LightGBMRegressionModel].getModel.model
+    val modelStr = fitModel.bestModel.asInstanceOf[LightGBMRegressionModel].getModel.modelStr.get
     assert(modelStr.contains("[lambda_l1: 0.1]") || modelStr.contains("[lambda_l1: 0.5]"))
     assert(modelStr.contains("[lambda_l2: 0.1]") || modelStr.contains("[lambda_l2: 0.5]"))
   }


### PR DESCRIPTION
add support for custom objective function in lightgbm learners

Users in the scala API will now be able to supply a custom loss function for training, which will need to output the gradient and hessian matrix.

As part of this PR, the LightGBMBooster and LightGBMDataset classes have been improved and moved under the booster and dataset folders, and some of the files related to parameters have been moved to a separate params folder in order to organize the code better since there are so many files in lightgbm directory.

TODO: add pyspark support, in a separate PR