### PR TITLE
feat: add singleton dataset mode for faster performance

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/io/http/SharedVariable.scala
+++ b/src/main/scala/com/microsoft/ml/spark/io/http/SharedVariable.scala
@@ -49,7 +49,6 @@ class SharedSingleton[T: ClassTag](constructor: => T) extends AnyRef with Serial
   }
 
   def get: T = instance
-
 }
 
 object SharedSingleton {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
@@ -40,11 +40,13 @@ class LightGBMClassifier(override val uid: String)
   def getIsUnbalance: Boolean = $(isUnbalance)
   def setIsUnbalance(value: Boolean): this.type = set(isUnbalance, value)
 
-  def getTrainParams(numTasks: Int, categoricalIndexes: Array[Int], dataset: Dataset[_]): TrainParams = {
+  def getTrainParams(numTasks: Int, categoricalIndexes: Array[Int],
+                     dataset: Dataset[_], numTasksPerExec: Int): TrainParams = {
     /* The native code for getting numClasses is always 1 unless it is multiclass-classification problem
      * so we infer the actual numClasses from the dataset here
      */
     val actualNumClasses = getNumClasses(dataset)
+    val isLocal = dataset.sparkSession.sparkContext.isLocal
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
     ClassifierTrainParams(getParallelism, getTopK, getNumIterations, getLearningRate, getNumLeaves, getMaxBin,
       getBinSampleCount, getBaggingFraction, getPosBaggingFraction, getNegBaggingFraction,
@@ -53,7 +55,7 @@ class LightGBMClassifier(override val uid: String)
       getIsUnbalance, getVerbosity, categoricalIndexes, actualNumClasses, getBoostFromAverage,
       getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric,
       getMetric, getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames,
-      getDelegate, getDartParams(), getExecutionParams(), getObjectiveParams())
+      getDelegate, getDartParams(), getExecutionParams(isLocal, numTasksPerExec), getObjectiveParams())
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
@@ -51,7 +51,9 @@ class LightGBMRanker(override val uid: String)
   def getEvalAt: Array[Int] = $(evalAt)
   def setEvalAt(value: Array[Int]): this.type = set(evalAt, value)
 
-  def getTrainParams(numTasks: Int, categoricalIndexes: Array[Int], dataset: Dataset[_]): TrainParams = {
+  def getTrainParams(numTasks: Int, categoricalIndexes: Array[Int],
+                     dataset: Dataset[_], numTasksPerExec: Int): TrainParams = {
+    val isLocal = dataset.sparkSession.sparkContext.isLocal
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
     RankerTrainParams(getParallelism, getTopK, getNumIterations, getLearningRate, getNumLeaves,
       getMaxBin, getBinSampleCount, getBaggingFraction, getPosBaggingFraction, getNegBaggingFraction,
@@ -59,8 +61,8 @@ class LightGBMRanker(override val uid: String)
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr,
       getVerbosity, categoricalIndexes, getBoostingType, getLambdaL1, getLambdaL2, getMaxPosition, getLabelGain,
       getIsProvideTrainingMetric, getMetric, getEvalAt, getMinGainToSplit, getMaxDeltaStep,
-      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getDartParams(), getExecutionParams(),
-      getObjectiveParams())
+      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getDartParams(),
+      getExecutionParams(isLocal, numTasksPerExec), getObjectiveParams())
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRankerModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
@@ -58,7 +58,9 @@ class LightGBMRegressor(override val uid: String)
   def getTweedieVariancePower: Double = $(tweedieVariancePower)
   def setTweedieVariancePower(value: Double): this.type = set(tweedieVariancePower, value)
 
-  def getTrainParams(numTasks: Int, categoricalIndexes: Array[Int], dataset: Dataset[_]): TrainParams = {
+  def getTrainParams(numTasks: Int, categoricalIndexes: Array[Int],
+                     dataset: Dataset[_], numTasksPerExec: Int): TrainParams = {
+    val isLocal = dataset.sparkSession.sparkContext.isLocal
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
     RegressorTrainParams(getParallelism, getTopK, getNumIterations, getLearningRate, getNumLeaves,
       getAlpha, getTweedieVariancePower, getMaxBin, getBinSampleCount, getBaggingFraction, getPosBaggingFraction,
@@ -66,7 +68,7 @@ class LightGBMRegressor(override val uid: String)
       getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr, getVerbosity, categoricalIndexes,
       getBoostFromAverage, getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric, getMetric,
       getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate,
-      getDartParams(), getExecutionParams(), getObjectiveParams())
+      getDartParams(), getExecutionParams(isLocal, numTasksPerExec), getObjectiveParams())
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRegressionModel = {

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/TrainUtils.scala
@@ -9,277 +9,34 @@ import java.net._
 import com.microsoft.ml.lightgbm._
 import com.microsoft.ml.spark.core.env.StreamUtilities._
 import com.microsoft.ml.spark.downloader.FaultToleranceUtils
+import com.microsoft.ml.spark.io.http.SharedSingleton
 import com.microsoft.ml.spark.lightgbm.booster.LightGBMBooster
-import com.microsoft.ml.spark.lightgbm.dataset.LightGBMDataset
+import com.microsoft.ml.spark.lightgbm.dataset.{DatasetUtils, LightGBMDataset, SingletonDataset}
 import com.microsoft.ml.spark.lightgbm.params.{ClassifierTrainParams, TrainParams}
-import com.microsoft.ml.spark.lightgbm.swig.SwigUtils
 import org.apache.spark.{BarrierTaskContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.ml.attribute._
-import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
-import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.StructType
 import org.slf4j.Logger
-
-import scala.collection.mutable.ListBuffer
 
 case class NetworkParams(defaultListenPort: Int, addr: String, port: Int, barrierExecutionMode: Boolean)
 case class ColumnParams(labelColumn: String, featuresColumn: String, weightColumn: Option[String],
                         initScoreColumn: Option[String], groupColumn: Option[String])
 
+private object TaskState {
+  var MainExecutorWorker: SharedSingleton[Long] = {
+    SharedSingleton(LightGBMUtils.getTaskId())
+  }
+
+  def resetSingleton(): Unit = {
+    SharedSingleton.poolClear()
+    MainExecutorWorker = {
+      SharedSingleton(LightGBMUtils.getTaskId())
+    }
+  }
+}
+
 private object TrainUtils extends Serializable {
-
-  def generateDataset(rowsIter: Iterator[Row], columnParams: ColumnParams,
-                      referenceDataset: Option[LightGBMDataset], schema: StructType,
-                      log: Logger, trainParams: TrainParams): Option[LightGBMDataset] = {
-    val (concatRowsIter: Iterator[Row], isSparse: Boolean) =
-      if (trainParams.executionParams.matrixType == "auto") {
-        sampleRowsForArrayType(rowsIter, schema, columnParams)
-      } else if (trainParams.executionParams.matrixType == "sparse") {
-        (rowsIter: Iterator[Row], true)
-      } else if (trainParams.executionParams.matrixType == "dense") {
-        (rowsIter: Iterator[Row], false)
-      } else {
-        throw new Exception(s"Invalid parameter matrix type specified: ${trainParams.executionParams.matrixType}")
-      }
-    var datasetPtr: Option[LightGBMDataset] = None
-    if (!isSparse) {
-      datasetPtr = aggregateDenseStreamedData(concatRowsIter, columnParams, referenceDataset, schema, log, trainParams)
-      // Validate generated dataset has the correct number of rows and cols
-      datasetPtr.get.validateDataset()
-    } else {
-      val rows = concatRowsIter.toArray
-      val numRows = rows.length
-      val labels = rows.map(row => row.getDouble(schema.fieldIndex(columnParams.labelColumn)))
-      val rowsAsSparse = rows.map(row => row.get(schema.fieldIndex(columnParams.featuresColumn)) match {
-        case dense: DenseVector => dense.toSparse
-        case sparse: SparseVector => sparse
-      })
-      val numCols = rowsAsSparse(0).size
-      val slotNames = getSlotNames(schema, columnParams.featuresColumn, numCols, trainParams)
-      log.info(s"LightGBM task generating sparse dataset with $numRows rows and $numCols columns")
-      datasetPtr = Some(LightGBMUtils.generateSparseDataset(rowsAsSparse, referenceDataset, slotNames, trainParams))
-      // Validate generated dataset has the correct number of rows and cols
-      datasetPtr.get.validateDataset()
-      datasetPtr.get.addFloatField(labels, "label", numRows)
-      columnParams.weightColumn.foreach { col =>
-        val weights = rows.map(row => row.getDouble(schema.fieldIndex(col)))
-        datasetPtr.get.addFloatField(weights, "weight", numRows)
-      }
-      addInitScoreColumn(rows, columnParams.initScoreColumn, datasetPtr, numRows, schema)
-      addGroupColumn(rows, columnParams.groupColumn, datasetPtr, numRows, schema, None)
-    }
-    datasetPtr
-  }
-
-  /**
-    * Sample the first several rows to determine whether to construct sparse or dense matrix in lightgbm native code.
-    * @param rowsIter  Iterator of rows.
-    * @param schema The schema.
-    * @param columnParams The column parameters.
-    * @return A reconstructed iterator with the same original rows and whether the matrix should be sparse or dense.
-    */
-  def sampleRowsForArrayType(rowsIter: Iterator[Row], schema: StructType,
-                             columnParams: ColumnParams): (Iterator[Row], Boolean) = {
-    val numSampledRows = 10
-    val sampleRows = rowsIter.take(numSampledRows).toArray
-    val numDense = sampleRows.map(row =>
-      row.get(schema.fieldIndex(columnParams.featuresColumn)).isInstanceOf[DenseVector]).filter(value => value).length
-    val numSparse = sampleRows.length - numDense
-    // recreate the iterator
-    (sampleRows.toIterator ++ rowsIter, numSparse > numDense)
-  }
-
-  def getRowAsDoubleArray(row: Row, columnParams: ColumnParams, schema: StructType): Array[Double] = {
-    row.get(schema.fieldIndex(columnParams.featuresColumn)) match {
-      case dense: DenseVector => dense.toArray
-      case sparse: SparseVector => sparse.toDense.toArray
-    }
-  }
-
-  def addFeaturesToChunkedArray(featuresChunkedArrayOpt: Option[doubleChunkedArray], numCols: Int,
-                  rowAsDoubleArray: Array[Double]): Unit = {
-    featuresChunkedArrayOpt.foreach { featuresChunkedArray =>
-      rowAsDoubleArray.foreach { doubleVal =>
-        featuresChunkedArray.add(doubleVal)
-      }
-    }
-  }
-
-  def addInitScoreColumnRow(initScoreChunkedArrayOpt: Option[doubleChunkedArray], row: Row,
-                            columnParams: ColumnParams, schema: StructType): Unit = {
-    columnParams.initScoreColumn.foreach { col =>
-      val field = schema.fields(schema.fieldIndex(col))
-      if (field.dataType == VectorType) {
-        val initScores = row.get(schema.fieldIndex(col)).asInstanceOf[DenseVector]
-        // Note: rows * # classes in multiclass case
-        initScores.values.foreach { rowValue =>
-          initScoreChunkedArrayOpt.get.add(rowValue)
-        }
-      } else {
-        val initScore = row.getDouble(schema.fieldIndex(col))
-        initScoreChunkedArrayOpt.get.add(initScore)
-      }
-    }
-  }
-
-  def addGroupColumnRow(row: Row, groupColumnValues: ListBuffer[Row],
-                        columnParams: ColumnParams, schema: StructType): Unit = {
-    columnParams.groupColumn.foreach { col =>
-      val colIdx = schema.fieldIndex(col)
-      groupColumnValues.append(Row(row.get(colIdx)))
-    }
-  }
-
-  def releaseArrays(labelsChunkedArray: floatChunkedArray, weightChunkedArrayOpt: Option[floatChunkedArray],
-                    initScoreChunkedArrayOpt: Option[doubleChunkedArray]): Unit = {
-    labelsChunkedArray.release()
-    weightChunkedArrayOpt.foreach(_.release())
-    initScoreChunkedArrayOpt.foreach(_.release())
-  }
-
-  def aggregateDenseStreamedData(rowsIter: Iterator[Row], columnParams: ColumnParams,
-                                 referenceDataset: Option[LightGBMDataset], schema: StructType,
-                                 log: Logger, trainParams: TrainParams): Option[LightGBMDataset] = {
-    var numRows = 0
-    val chunkSize = trainParams.executionParams.chunkSize
-    val labelsChunkedArray = new floatChunkedArray(chunkSize)
-    val weightChunkedArrayOpt = columnParams.weightColumn.map { _ => new floatChunkedArray(chunkSize) }
-    val initScoreChunkedArrayOpt = columnParams.initScoreColumn.map { _ => new doubleChunkedArray(chunkSize) }
-    var featuresChunkedArrayOpt: Option[doubleChunkedArray] = None
-    val groupColumnValues: ListBuffer[Row] = new ListBuffer[Row]()
-    try {
-      var numCols = 0
-      while (rowsIter.hasNext) {
-        val row = rowsIter.next()
-        numRows += 1
-        labelsChunkedArray.add(row.getDouble(schema.fieldIndex(columnParams.labelColumn)).toFloat)
-        columnParams.weightColumn.map { col =>
-          weightChunkedArrayOpt.get.add(row.getDouble(schema.fieldIndex(col)).toFloat)
-        }
-        val rowAsDoubleArray = getRowAsDoubleArray(row, columnParams, schema)
-        numCols = rowAsDoubleArray.length
-        if (featuresChunkedArrayOpt.isEmpty) {
-          featuresChunkedArrayOpt = Some(new doubleChunkedArray(numCols * chunkSize))
-        }
-        addFeaturesToChunkedArray(featuresChunkedArrayOpt, numCols, rowAsDoubleArray)
-        addInitScoreColumnRow(initScoreChunkedArrayOpt, row, columnParams, schema)
-        addGroupColumnRow(row, groupColumnValues, columnParams, schema)
-      }
-
-      val slotNames = getSlotNames(schema, columnParams.featuresColumn, numCols, trainParams)
-      log.info(s"LightGBM task generating dense dataset with $numRows rows and $numCols columns")
-      val datasetPtr = Some(LightGBMUtils.generateDenseDataset(numRows, numCols, featuresChunkedArrayOpt.get,
-        referenceDataset, slotNames, trainParams, chunkSize))
-      datasetPtr.get.addFloatField(labelsChunkedArray, "label", numRows)
-
-      weightChunkedArrayOpt.foreach(datasetPtr.get.addFloatField(_, "weight", numRows))
-      initScoreChunkedArrayOpt.foreach(datasetPtr.get.addDoubleField(_, "init_score", numRows))
-      val overrideGroupIndex = Some(0)
-      addGroupColumn(groupColumnValues.toArray, columnParams.groupColumn, datasetPtr, numRows, schema,
-        overrideGroupIndex)
-      datasetPtr
-    } finally {
-      releaseArrays(labelsChunkedArray, weightChunkedArrayOpt, initScoreChunkedArrayOpt)
-    }
-  }
-
-  trait CardinalityType[T]
-
-  object CardinalityTypes {
-
-    implicit object LongType extends CardinalityType[Long]
-
-    implicit object IntType extends CardinalityType[Int]
-
-    implicit object StringType extends CardinalityType[String]
-
-  }
-
-  import CardinalityTypes._
-
-  def addInitScoreColumn(rows: Array[Row], initScoreColumn: Option[String],
-                         datasetPtr: Option[LightGBMDataset], numRows: Int, schema: StructType): Unit = {
-    initScoreColumn.foreach { col =>
-      val field = schema.fields(schema.fieldIndex(col))
-      if (field.dataType == VectorType) {
-        val initScores = rows.map(row => row.get(schema.fieldIndex(col)).asInstanceOf[DenseVector])
-        // Calculate # rows * # classes in multiclass case
-        val initScoresLength = initScores.length
-        val totalLength = initScoresLength * initScores(0).size
-        val flattenedInitScores = new Array[Double](totalLength)
-        initScores.zipWithIndex.foreach { case (rowVector, rowIndex) =>
-          rowVector.values.zipWithIndex.foreach { case (rowValue, colIndex) =>
-            flattenedInitScores(colIndex * initScoresLength + rowIndex) = rowValue
-          }
-        }
-        datasetPtr.get.addDoubleField(flattenedInitScores, "init_score", numRows)
-      } else {
-        val initScores = rows.map(row => row.getDouble(schema.fieldIndex(col)))
-        datasetPtr.get.addDoubleField(initScores, "init_score", numRows)
-      }
-    }
-  }
-
-  def validateGroupColumn(groupColumn: Option[String], schema: StructType): Unit = {
-    groupColumn.foreach { col =>
-      val datatype = schema.fields(schema.fieldIndex(col)).dataType
-
-      if (datatype != org.apache.spark.sql.types.IntegerType
-        && datatype != org.apache.spark.sql.types.LongType
-        && datatype != org.apache.spark.sql.types.StringType) {
-        throw new IllegalArgumentException(
-          s"group column $col must be of type Long, Int or String but is ${datatype.typeName}")
-      }
-    }
-  }
-
-  def addGroupColumn(rows: Array[Row], groupColumn: Option[String],
-                     datasetPtr: Option[LightGBMDataset], numRows: Int,
-                     schema: StructType, overrideIdx: Option[Int]): Unit = {
-    validateGroupColumn(groupColumn, schema)
-    groupColumn.foreach { col =>
-      val datatype = schema.fields(schema.fieldIndex(col)).dataType
-      val colIdx = if (overrideIdx.isEmpty) schema.fieldIndex(col) else overrideIdx.get
-
-      // Convert to distinct count (note ranker should have sorted within partition by group id)
-      // We use a triplet of a list of cardinalities, last unique value and unique value count
-      val groupCardinality = datatype match {
-        case org.apache.spark.sql.types.IntegerType => countCardinality(rows.map(row => row.getInt(colIdx)))
-        case org.apache.spark.sql.types.LongType => countCardinality(rows.map(row => row.getLong(colIdx)))
-        case org.apache.spark.sql.types.StringType => countCardinality(rows.map(row => row.getString(colIdx)))
-      }
-
-      datasetPtr.get.addIntField(groupCardinality, "group", groupCardinality.length)
-    }
-  }
-
-  case class CardinalityTriplet[T](groupCounts: List[Int], currentValue: T, currentCount: Int)
-
-  def countCardinality[T](input: Seq[T])(implicit ev: CardinalityType[T]): Array[Int] = {
-    val default: T = null.asInstanceOf[T]
-
-    val cardinalityTriplet = input.foldLeft(CardinalityTriplet(List.empty[Int], default, 0)) {
-      case (listValue: CardinalityTriplet[T], currentValue) =>
-
-        if (listValue.groupCounts.isEmpty && listValue.currentCount == 0) {
-          // Base case, keep list as empty and set cardinality to 1
-          CardinalityTriplet(listValue.groupCounts, currentValue, 1)
-        }
-        else if (listValue.currentValue == currentValue) {
-          // Encountered same value
-          CardinalityTriplet(listValue.groupCounts, currentValue, listValue.currentCount + 1)
-        }
-        else {
-          // New value, need to reset counter and add new cardinality to list
-          CardinalityTriplet(listValue.currentCount :: listValue.groupCounts, currentValue, 1)
-        }
-    }
-
-    val groupCardinality = (cardinalityTriplet.currentCount :: cardinalityTriplet.groupCounts).reverse.toArray
-    groupCardinality
-  }
 
   def createBooster(trainParams: TrainParams, trainDatasetPtr: LightGBMDataset,
                     validDatasetPtr: Option[LightGBMDataset]): LightGBMBooster = {
@@ -328,22 +85,15 @@ private object TrainUtils extends Serializable {
                          log: Logger,
                          iters: Int): Boolean = {
     var isFinished = false
-    val isFinishedPtr = lightgbmlib.new_intp()
     try {
-      val result =
         if (trainParams.objectiveParams.fobj.isDefined) {
           val classification = trainParams.isInstanceOf[ClassifierTrainParams]
           val (gradient, hessian) = trainParams.objectiveParams.fobj.get.getGradient(
             booster.innerPredict(0, classification), booster.trainDataset.get)
-          val gradPtr = SwigUtils.floatArrayToNative(gradient)
-          val hessPtr = SwigUtils.floatArrayToNative(hessian)
-          lightgbmlib.LGBM_BoosterUpdateOneIterCustom(booster.boosterHandler.boosterPtr,
-            gradPtr, hessPtr, isFinishedPtr)
+          isFinished = booster.updateOneIterationCustom(gradient, hessian)
         } else {
-          lightgbmlib.LGBM_BoosterUpdateOneIter(booster.boosterHandler.boosterPtr, isFinishedPtr)
+          isFinished = booster.updateOneIteration()
         }
-      LightGBMUtils.validate(result, "Booster Update One Iter")
-      isFinished = lightgbmlib.intp_value(isFinishedPtr) == 1
       log.info("LightGBM running iteration: " + iters + " with is finished: " + isFinished)
     } catch {
       case e: java.lang.Exception =>
@@ -351,8 +101,6 @@ private object TrainUtils extends Serializable {
           " stopping training on task. This message should rarely occur." +
           " Inner exception: " + e.toString)
         isFinished = true
-    } finally {
-      lightgbmlib.delete_intp(isFinishedPtr)
     }
     isFinished
   }
@@ -374,7 +122,7 @@ private object TrainUtils extends Serializable {
       val newLearningRate = getLearningRate(batchIndex, partitionId, iters, log, trainParams,
         learningRate)
       if (newLearningRate != learningRate) {
-        log.info(s"LightGBM task calling LGBM_BoosterResetParameter to reset learningRate" +
+        log.info(s"LightGBM task calling booster.resetParameter to reset learningRate" +
           s" (newLearningRate: $newLearningRate)")
         booster.resetParameter(s"learning_rate=$newLearningRate")
         learningRate = newLearningRate
@@ -426,26 +174,6 @@ private object TrainUtils extends Serializable {
     bestIterResult
   }
 
-  def getSlotNames(schema: StructType, featuresColumn: String, numCols: Int,
-                   trainParams: TrainParams): Option[Array[String]] = {
-    if (trainParams.featureNames.nonEmpty) {
-      Some(trainParams.featureNames)
-    } else {
-      val featuresSchema = schema.fields(schema.fieldIndex(featuresColumn))
-      val metadata = AttributeGroup.fromStructField(featuresSchema)
-      if (metadata.attributes.isEmpty) None
-      else if (metadata.attributes.get.isEmpty) None
-      else {
-        val colnames = (0 until numCols).map(_.toString).toArray
-        metadata.attributes.get.foreach {
-          case attr =>
-            attr.index.foreach(index => colnames(index) = attr.name.getOrElse(index.toString))
-        }
-        Some(colnames)
-      }
-    }
-  }
-
   def beforeGenerateTrainDataset(batchIndex: Int, columnParams: ColumnParams, schema: StructType,
                                  log: Logger, trainParams: TrainParams): Unit = {
     if(trainParams.delegate.isDefined) {
@@ -485,12 +213,12 @@ private object TrainUtils extends Serializable {
     var validDatasetOpt: Option[LightGBMDataset] = None
     try {
       beforeGenerateTrainDataset(batchIndex, columnParams, schema, log, trainParams)
-      trainDatasetOpt = generateDataset(inputRows, columnParams, None, schema, log, trainParams)
+      trainDatasetOpt = DatasetUtils.generateDataset(inputRows, columnParams, None, schema, log, trainParams)
       afterGenerateTrainDataset(batchIndex, columnParams, schema, log, trainParams)
 
       if (validationData.isDefined) {
         beforeGenerateValidDataset(batchIndex, columnParams, schema, log, trainParams)
-        validDatasetOpt = generateDataset(validationData.get.value.toIterator, columnParams,
+        validDatasetOpt = DatasetUtils.generateDataset(validationData.get.value.toIterator, columnParams,
           trainDatasetOpt, schema, log, trainParams)
         afterGenerateValidDataset(batchIndex, columnParams, schema, log, trainParams)
       }
@@ -521,7 +249,7 @@ private object TrainUtils extends Serializable {
   }
 
   private def findOpenPort(defaultListenPort: Int, numTasksPerExec: Int, log: Logger): Socket = {
-    val basePort = defaultListenPort + (LightGBMUtils.getId() * numTasksPerExec)
+    val basePort = defaultListenPort + (LightGBMUtils.getWorkerId() * numTasksPerExec)
     if (basePort > LightGBMConstants.MaxPort) {
       throw new Exception(s"Error: port $basePort out of range, possibly due to too many executors or unknown error")
     }
@@ -565,7 +293,7 @@ private object TrainUtils extends Serializable {
 
   def getNetworkInitNodes(networkParams: NetworkParams,
                           localListenPort: Int, log: Logger,
-                          emptyPartition: Boolean): String = {
+                          ignoreTask: Boolean): String = {
     using(new Socket(networkParams.addr, networkParams.port)) {
       driverSocket =>
         usingMany(Seq(new BufferedReader(new InputStreamReader(driverSocket.getInputStream)),
@@ -574,7 +302,7 @@ private object TrainUtils extends Serializable {
             val driverInput = io(0).asInstanceOf[BufferedReader]
             val driverOutput = io(1).asInstanceOf[BufferedWriter]
             val taskStatus =
-              if (emptyPartition) {
+              if (ignoreTask) {
                 log.info("send empty status to driver")
                 LightGBMConstants.IgnoreStatus
               } else {
@@ -645,44 +373,129 @@ private object TrainUtils extends Serializable {
     mainPort.toInt
   }
 
+  /** If using single dataset mode, only returns one task in JVM.
+    * Otherwise, returns true for all tasks.
+    * @param trainParams The training parameters.
+    * @param log The logger.
+    * @return Whether the current task is enabled.
+    */
+  def getIsEnabledWorker(trainParams: TrainParams, log: Logger): Boolean = {
+    if (trainParams.executionParams.useSingleDatasetMode) {
+      // Find all workers in current JVM
+      val mainExecutorWorker = TaskState.MainExecutorWorker.get
+      val myTaskId = LightGBMUtils.getTaskId()
+      val isMainWorker = mainExecutorWorker == myTaskId
+      log.info(s"Using singleDatasetMode.  " +
+        s"Is main worker: ${isMainWorker} for task id: ${myTaskId} and main task id: ${mainExecutorWorker}")
+      if (!isMainWorker) {
+        SingletonDataset.incrementDoneSignal()
+      }
+      isMainWorker
+    } else {
+      true
+    }
+  }
+
+  /** Retrieve the network nodes and current port information.
+    *
+    * Establish local socket connection.
+    *
+    * Note: Ideally we would start the socket connections in the C layer, this opens us up for
+    * race conditions in case other applications open sockets on cluster, but usually this
+    * should not be a problem
+    *
+    * @param networkParams The network parameters.
+    * @param numTasksPerExec The number of tasks per executor.
+    * @param log The logger.
+    * @param isEnabledWorker True if the current worker is enabled, including whether the partition
+    *                        was enabled and this is the chosen worker to initialize the network connection.
+    * @return A tuple containing the string with all nodes and the current worker's open socket connection.
+    */
+  def getNetworkInfo(networkParams: NetworkParams, numTasksPerExec: Int,
+                     log: Logger, isEnabledWorker: Boolean): (String, Int) = {
+    using(findOpenPort(networkParams.defaultListenPort, numTasksPerExec, log)) {
+      openPort =>
+        val localListenPort = openPort.getLocalPort
+        log.info(s"LightGBM task connecting to host: ${networkParams.addr} and port: ${networkParams.port}")
+        FaultToleranceUtils.retryWithTimeout() {
+          (getNetworkInitNodes(networkParams, localListenPort, log, !isEnabledWorker), localListenPort)
+        }
+    }.get
+  }
+
+  /** Return true if the current thread will return the booster after training is complete.
+    *
+    * Also sets up the concurrency signals on workers if using single dataset mode.
+    *
+    * @param isEnabledWorker True if the current worker is enabled, including whether the partition
+    *                        was enabled and this is the chosen worker to initialize the network connection.
+    * @param nodes The string representation of all nodes communicating in the network.
+    * @param log The logger.
+    * @param useSingleDatasetMode True if using single dataset mode.
+    * @param numTasksPerExec The number of tasks per executor.
+    * @param localListenPort The local port used to setup the network ring of communication.
+    * @return Boolean representing whether the current task will return the booster or not.
+    */
+  def getReturnBooster(isEnabledWorker: Boolean, nodes: String, log: Logger,
+                       useSingleDatasetMode: Boolean, numTasksPerExec: Int,
+                       localListenPort: Int): Boolean = {
+    if (!isEnabledWorker) {
+      false
+    } else {
+      val mainWorkerPort = getMainWorkerPort(nodes, log)
+      mainWorkerPort == localListenPort
+    }
+  }
+
   def trainLightGBM(batchIndex: Int, networkParams: NetworkParams, columnParams: ColumnParams,
                     validationData: Option[Broadcast[Array[Row]]], log: Logger,
                     trainParams: TrainParams, numTasksPerExec: Int, schema: StructType)
                    (inputRows: Iterator[Row]): Iterator[LightGBMBooster] = {
-    val emptyPartition = !inputRows.hasNext
-    // Ideally we would start the socket connections in the C layer, this opens us up for
-    // race conditions in case other applications open sockets on cluster, but usually this
-    // should not be a problem
-    val (nodes, localListenPort) = using(findOpenPort(networkParams.defaultListenPort, numTasksPerExec, log)) {
-      openPort =>
-        val localListenPort = openPort.getLocalPort
-        // Initialize the native library
-        LightGBMUtils.initializeNativeLibrary()
-        log.info(s"LightGBM task connecting to host: ${networkParams.addr} and port: ${networkParams.port}")
-        FaultToleranceUtils.retryWithTimeout() {
-          (getNetworkInitNodes(networkParams, localListenPort, log, emptyPartition), localListenPort)
-        }
-    }.get
-
-    if (emptyPartition) {
-      log.warn("LightGBM task encountered empty partition, for best performance ensure no partitions empty")
-      List[LightGBMBooster]().toIterator
-    } else {
+    var isEnabledWorker = false
+    try {
+      val emptyPartition = !inputRows.hasNext
+      val useSingleDatasetMode = trainParams.executionParams.useSingleDatasetMode
+      isEnabledWorker = if (!emptyPartition) getIsEnabledWorker(trainParams, log) else false
+      // Initialize the native library
+      LightGBMUtils.initializeNativeLibrary()
       // Initialize the network communication
-      log.info(s"LightGBM task listening on: $localListenPort")
-      // Return booster only from main worker to reduce network communication overhead
-      val mainWorkerPort = getMainWorkerPort(nodes, log)
-      val returnBooster = mainWorkerPort == localListenPort
-      try {
-        val retries = 3
-        val initialDelay = 1000L
-        networkInit(nodes, localListenPort, log, retries, initialDelay)
-        translate(batchIndex, columnParams, validationData, log, trainParams, returnBooster, schema, inputRows)
-      } finally {
-        // Finalize network when done
-        LightGBMUtils.validate(lightgbmlib.LGBM_NetworkFree(), "Finalize network")
+      val (nodes, localListenPort) = getNetworkInfo(networkParams, numTasksPerExec, log, isEnabledWorker)
+      if (emptyPartition) {
+        log.warn("LightGBM task encountered empty partition, for best performance ensure no partitions empty")
+        List[LightGBMBooster]().toIterator
+      } else {
+        if (isEnabledWorker) {
+          log.info(s"LightGBM task listening on: $localListenPort")
+        }
+        // Return booster only from main worker to reduce network communication overhead
+        val returnBooster = getReturnBooster(isEnabledWorker, nodes, log, useSingleDatasetMode,
+          numTasksPerExec, localListenPort)
+        try {
+          val retries = 3
+          val initialDelay = 1000L
+          if (isEnabledWorker) {
+            // If worker enabled, initialize the network ring of communication
+            networkInit(nodes, localListenPort, log, retries, initialDelay)
+            translate(batchIndex, columnParams, validationData, log, trainParams, returnBooster, schema, inputRows)
+          } else {
+            // Otherwise, if using singleDatasetMode, push the dataset rows to the singleton dataset to be
+            // passed by the main task to the native side
+            DatasetUtils.pushRowsToSingletonDataset(inputRows, columnParams, schema, trainParams)
+            List[LightGBMBooster]().toIterator
+          }
+        } finally {
+          if (isEnabledWorker) {
+            // Finalize network when done
+            LightGBMUtils.validate(lightgbmlib.LGBM_NetworkFree(), "Finalize network")
+          }
+        }
+      }
+    } finally {
+      if (isEnabledWorker) {
+        // Clear the singleton pool and reset the dataset singleton state
+        TaskState.resetSingleton()
+        SingletonDataset.resetSingletonDatasetState()
       }
     }
   }
-
 }

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/dataset/DatasetAggregator.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/dataset/DatasetAggregator.scala
@@ -1,0 +1,137 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm.dataset
+
+import com.microsoft.ml.lightgbm.{doubleChunkedArray, floatChunkedArray}
+import com.microsoft.ml.spark.lightgbm.ColumnParams
+import com.microsoft.ml.spark.lightgbm.dataset.DatasetUtils.{addFeaturesToChunkedArray, addGroupColumnRow,
+  addInitScoreColumnRow, getRowAsDoubleArray}
+import org.apache.spark.ml.linalg.SparseVector
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+
+
+/**
+  * Defines class for aggregating rows to a single structure before creating the native LightGBMDataset.
+  * @param synchronized If true, locks when adding rows to the SparseDatasetAggregator structure.
+  */
+class SparseDatasetAggregator(synchronized: Boolean) {
+  val labelsArray = ArrayBuffer.empty[Double]
+  var weightArrayOpt: Option[ArrayBuffer[Double]] = None
+  var initScoreArrayOpt: Option[ArrayBuffer[Double]] = None
+  var featuresArray = ArrayBuffer.empty[SparseVector]
+  val groupColumnValuesArray: ListBuffer[Row] = new ListBuffer[Row]()
+  var rowCount: Int = 0
+
+  /** Adds the rows to the internal data structure.
+    * @param labels The column of label values.
+    * @param weightsOpt The optional column of weights, if specified.
+    * @param initScoresOpt The optional column of initial scores, if specified.
+    * @param features The column of feature vectors as SparseVector.
+    * @param groupColumnValues The column of group values, if in ranking scenario.
+    */
+  def addRows(labels: Array[Double], weightsOpt: Option[Array[Double]],
+              initScoresOpt: Option[Array[Double]],
+              features: Array[SparseVector],
+              groupColumnValues: ListBuffer[Row]): Unit = {
+    if (synchronized) {
+      this.synchronized {
+        innerAddRows(labels, weightsOpt, initScoresOpt, features, groupColumnValues)
+      }
+    } else {
+      innerAddRows(labels, weightsOpt, initScoresOpt, features, groupColumnValues)
+    }
+  }
+
+  /** Adds the rows to the internal data structure.
+    * @param labels The column of label values.
+    * @param weightsOpt The optional column of weights, if specified.
+    * @param initScoresOpt The optional column of initial scores, if specified.
+    * @param features The column of feature vectors as SparseVector.
+    * @param groupColumnValues The column of group values, if in ranking scenario.
+    */
+  private def innerAddRows(labels: Array[Double], weightsOpt: Option[Array[Double]],
+                           initScoresOpt: Option[Array[Double]],
+                           features: Array[SparseVector],
+                           groupColumnValues: ListBuffer[Row]): Unit = {
+    rowCount += labels.length
+    labelsArray ++= labels
+    weightsOpt.foreach { weights =>
+      if (weightArrayOpt.isEmpty) {
+        val weightArray = ArrayBuffer.empty[Double]
+        weightArray ++= weights
+        weightArrayOpt = Some(weightArray)
+      } else {
+        weightArrayOpt.get ++= weights
+      }
+    }
+    initScoresOpt.foreach { initScores =>
+      if (initScoreArrayOpt.isEmpty) {
+        val initScoresArray = ArrayBuffer.empty[Double]
+        initScoresArray ++= initScores
+        initScoreArrayOpt = Some(initScoresArray)
+      } else {
+        initScoreArrayOpt.get ++= initScores
+      }
+    }
+    featuresArray ++= features
+    groupColumnValuesArray ++= groupColumnValues
+  }
+}
+
+/** Defines class for aggregating rows to a single structure before creating the native LightGBMDataset.
+  * @param columnParams The column parameters.
+  * @param chunkSize The chunk size for the chunked arrays.
+  * @param numCols The number of columns in the dataset.
+  * @param schema The schema.
+  * @param synchronized If true, locks when adding rows to the DenseDatasetAggregator structure.
+  */
+class DenseDatasetAggregator(columnParams: ColumnParams, chunkSize: Int, numCols: Int,
+                             schema: StructType, synchronized: Boolean) {
+  val labelsChunkedArray = new floatChunkedArray(chunkSize)
+  val weightChunkedArrayOpt = columnParams.weightColumn.map {
+    _ => new floatChunkedArray(chunkSize)
+  }
+  val initScoreChunkedArrayOpt = columnParams.initScoreColumn.map {
+    _ => new doubleChunkedArray(chunkSize)
+  }
+  var featuresChunkedArray = new doubleChunkedArray(numCols * chunkSize)
+  val groupColumnValues: ListBuffer[Row] = new ListBuffer[Row]()
+  var rowCount: Int = 0
+
+  /** Adds the rows to the internal data structure.
+    * @param rowsIter The rows from the dataset as an iterator.
+    */
+  def addRows(rowsIter: Iterator[Row]): Unit = {
+    if (synchronized) {
+      this.synchronized {
+        innerAddRow(rowsIter)
+      }
+    } else {
+      innerAddRow(rowsIter)
+    }
+  }
+
+  /** Adds the rows to the internal data structure.
+    * @param rowsIter The rows from the dataset as an iterator.
+    */
+  private def innerAddRow(rowsIter: Iterator[Row]): Unit = {
+    // TODO: This can be optimized, right now all of the tasks will be locked on this
+    // Note: We can't do this out of order though otherwise it will break ranker group column
+    while (rowsIter.hasNext) {
+      rowCount += 1
+      val row = rowsIter.next()
+      labelsChunkedArray.add(row.getDouble(schema.fieldIndex(columnParams.labelColumn)).toFloat)
+      columnParams.weightColumn.map { col =>
+        weightChunkedArrayOpt.get.add(row.getDouble(schema.fieldIndex(col)).toFloat)
+      }
+      val rowAsDoubleArray = getRowAsDoubleArray(row, columnParams, schema)
+      addFeaturesToChunkedArray(featuresChunkedArray, rowAsDoubleArray)
+      addInitScoreColumnRow(initScoreChunkedArrayOpt, row, columnParams, schema)
+      addGroupColumnRow(row, groupColumnValues, columnParams, schema)
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/dataset/DatasetUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/dataset/DatasetUtils.scala
@@ -1,0 +1,358 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm.dataset
+
+import com.microsoft.ml.lightgbm.{doubleChunkedArray, floatChunkedArray}
+import com.microsoft.ml.spark.lightgbm.{ColumnParams, LightGBMUtils}
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+import com.microsoft.ml.spark.lightgbm.params.TrainParams
+import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+import org.slf4j.Logger
+
+import scala.collection.mutable.ListBuffer
+
+object DatasetUtils {
+
+  def pushRowsToSingletonDataset(rowsIter: Iterator[Row], columnParams: ColumnParams,
+                                 schema: StructType, trainParams: TrainParams): Unit = {
+    var (concatRowsIter: Iterator[Row], isSparse: Boolean) = getArrayType(rowsIter, columnParams, schema, trainParams)
+    // Note: the first worker sets "is sparse", other workers read it
+    SingletonDataset.linkIsSparse(isSparse)
+    isSparse = SingletonDataset.IsSparse.get.get
+    if (!isSparse) {
+      val headRow = concatRowsIter.next()
+      val rowAsDoubleArray = getRowAsDoubleArray(headRow, columnParams, schema)
+      val numCols = rowAsDoubleArray.length
+      val chunkSize = trainParams.executionParams.chunkSize
+      SingletonDataset.setupDenseDatasetState(columnParams, chunkSize, numCols, schema)
+      val denseDatasetAggregator = SingletonDataset.DenseDatasetState.get.get
+      copyRowsToChunkedArrays(headRow, concatRowsIter, denseDatasetAggregator)
+    } else {
+      SingletonDataset.setupSparseDatasetState()
+      val sparseDatasetAggregator = SingletonDataset.SparseDatasetState.get.get
+      copyRowsToSparseDataset(concatRowsIter, columnParams, schema, sparseDatasetAggregator)
+    }
+    SingletonDataset.DoneSignal.countDown()
+  }
+
+  def getArrayType(rowsIter: Iterator[Row],
+                   columnParams: ColumnParams,
+                   schema: StructType,
+                   trainParams: TrainParams): (Iterator[Row], Boolean) = {
+      if (trainParams.executionParams.matrixType == "auto") {
+        sampleRowsForArrayType(rowsIter, schema, columnParams)
+      } else if (trainParams.executionParams.matrixType == "sparse") {
+        (rowsIter: Iterator[Row], true)
+      } else if (trainParams.executionParams.matrixType == "dense") {
+        (rowsIter: Iterator[Row], false)
+      } else {
+        throw new Exception(s"Invalid parameter matrix type specified: ${trainParams.executionParams.matrixType}")
+      }
+  }
+
+  def generateDataset(rowsIter: Iterator[Row], columnParams: ColumnParams,
+                      referenceDataset: Option[LightGBMDataset], schema: StructType,
+                      log: Logger, trainParams: TrainParams): Option[LightGBMDataset] = {
+    var (concatRowsIter: Iterator[Row], isSparse: Boolean) = getArrayType(rowsIter, columnParams, schema, trainParams)
+    if (trainParams.executionParams.useSingleDatasetMode) {
+      SingletonDataset.linkIsSparse(isSparse)
+      isSparse = SingletonDataset.IsSparse.get.get
+    }
+    var dataset: Option[LightGBMDataset] = None
+    if (!isSparse) {
+      dataset = aggregateDenseStreamedData(concatRowsIter, columnParams, referenceDataset, schema, log, trainParams)
+    } else {
+      dataset = aggregateSparseStreamedData(concatRowsIter, columnParams, referenceDataset, schema, log, trainParams)
+    }
+    // Validate generated dataset has the correct number of rows and cols
+    dataset.get.validateDataset()
+    dataset
+  }
+
+  trait CardinalityType[T]
+
+  object CardinalityTypes {
+
+    implicit object LongType extends CardinalityType[Long]
+
+    implicit object IntType extends CardinalityType[Int]
+
+    implicit object StringType extends CardinalityType[String]
+
+  }
+
+  import CardinalityTypes._
+
+
+  case class CardinalityTriplet[T](groupCounts: List[Int], currentValue: T, currentCount: Int)
+
+  def countCardinality[T](input: Seq[T])(implicit ev: CardinalityType[T]): Array[Int] = {
+    val default: T = null.asInstanceOf[T]
+
+    val cardinalityTriplet = input.foldLeft(CardinalityTriplet(List.empty[Int], default, 0)) {
+      case (listValue: CardinalityTriplet[T], currentValue) =>
+
+        if (listValue.groupCounts.isEmpty && listValue.currentCount == 0) {
+          // Base case, keep list as empty and set cardinality to 1
+          CardinalityTriplet(listValue.groupCounts, currentValue, 1)
+        }
+        else if (listValue.currentValue == currentValue) {
+          // Encountered same value
+          CardinalityTriplet(listValue.groupCounts, currentValue, listValue.currentCount + 1)
+        }
+        else {
+          // New value, need to reset counter and add new cardinality to list
+          CardinalityTriplet(listValue.currentCount :: listValue.groupCounts, currentValue, 1)
+        }
+    }
+
+    val groupCardinality = (cardinalityTriplet.currentCount :: cardinalityTriplet.groupCounts).reverse.toArray
+    groupCardinality
+  }
+
+  def getInitScores(rows: Array[Row], initScoreColumn: Option[String],
+                    schema: StructType): Option[Array[Double]] = {
+    initScoreColumn.map { col =>
+      val field = schema.fields(schema.fieldIndex(col))
+      if (field.dataType == VectorType) {
+        val initScores = rows.map(row => row.get(schema.fieldIndex(col)).asInstanceOf[DenseVector])
+        // Calculate # rows * # classes in multiclass case
+        val initScoresLength = initScores.length
+        val totalLength = initScoresLength * initScores(0).size
+        val flattenedInitScores = new Array[Double](totalLength)
+        initScores.zipWithIndex.foreach { case (rowVector, rowIndex) =>
+          rowVector.values.zipWithIndex.foreach { case (rowValue, colIndex) =>
+            flattenedInitScores(colIndex * initScoresLength + rowIndex) = rowValue
+          }
+        }
+        flattenedInitScores
+      } else {
+        rows.map(row => row.getDouble(schema.fieldIndex(col)))
+      }
+    }
+  }
+
+  def addGroupColumn(rows: Array[Row], groupColumn: Option[String],
+                     datasetPtr: Option[LightGBMDataset], numRows: Int,
+                     schema: StructType, overrideIdx: Option[Int]): Unit = {
+    validateGroupColumn(groupColumn, schema)
+    groupColumn.foreach { col =>
+      val datatype = schema.fields(schema.fieldIndex(col)).dataType
+      val colIdx = if (overrideIdx.isEmpty) schema.fieldIndex(col) else overrideIdx.get
+
+      // Convert to distinct count (note ranker should have sorted within partition by group id)
+      // We use a triplet of a list of cardinalities, last unique value and unique value count
+      val groupCardinality = datatype match {
+        case org.apache.spark.sql.types.IntegerType => countCardinality(rows.map(row => row.getInt(colIdx)))
+        case org.apache.spark.sql.types.LongType => countCardinality(rows.map(row => row.getLong(colIdx)))
+        case org.apache.spark.sql.types.StringType => countCardinality(rows.map(row => row.getString(colIdx)))
+      }
+
+      datasetPtr.get.addIntField(groupCardinality, "group", groupCardinality.length)
+    }
+  }
+
+
+  /**
+    * Sample the first several rows to determine whether to construct sparse or dense matrix in lightgbm native code.
+    * @param rowsIter  Iterator of rows.
+    * @param schema The schema.
+    * @param columnParams The column parameters.
+    * @return A reconstructed iterator with the same original rows and whether the matrix should be sparse or dense.
+    */
+  def sampleRowsForArrayType(rowsIter: Iterator[Row], schema: StructType,
+                             columnParams: ColumnParams): (Iterator[Row], Boolean) = {
+    val numSampledRows = 10
+    val sampleRows = rowsIter.take(numSampledRows).toArray
+    val numDense = sampleRows.map(row =>
+      row.get(schema.fieldIndex(columnParams.featuresColumn)).isInstanceOf[DenseVector]).filter(value => value).length
+    val numSparse = sampleRows.length - numDense
+    // recreate the iterator
+    (sampleRows.toIterator ++ rowsIter, numSparse > numDense)
+  }
+
+  def getRowAsDoubleArray(row: Row, columnParams: ColumnParams, schema: StructType): Array[Double] = {
+    row.get(schema.fieldIndex(columnParams.featuresColumn)) match {
+      case dense: DenseVector => dense.toArray
+      case sparse: SparseVector => sparse.toDense.toArray
+    }
+  }
+
+  def addFeaturesToChunkedArray(featuresChunkedArray: doubleChunkedArray,
+                                rowAsDoubleArray: Array[Double]): Unit = {
+    rowAsDoubleArray.foreach { doubleVal =>
+      featuresChunkedArray.add(doubleVal)
+    }
+  }
+
+  def addInitScoreColumnRow(initScoreChunkedArrayOpt: Option[doubleChunkedArray], row: Row,
+                            columnParams: ColumnParams, schema: StructType): Unit = {
+    columnParams.initScoreColumn.foreach { col =>
+      val field = schema.fields(schema.fieldIndex(col))
+      if (field.dataType == VectorType) {
+        val initScores = row.get(schema.fieldIndex(col)).asInstanceOf[DenseVector]
+        // Note: rows * # classes in multiclass case
+        initScores.values.foreach { rowValue =>
+          initScoreChunkedArrayOpt.get.add(rowValue)
+        }
+      } else {
+        val initScore = row.getDouble(schema.fieldIndex(col))
+        initScoreChunkedArrayOpt.get.add(initScore)
+      }
+    }
+  }
+
+  def addGroupColumnRow(row: Row, groupColumnValues: ListBuffer[Row],
+                        columnParams: ColumnParams, schema: StructType): Unit = {
+    columnParams.groupColumn.foreach { col =>
+      val colIdx = schema.fieldIndex(col)
+      groupColumnValues.append(Row(row.get(colIdx)))
+    }
+  }
+
+  def releaseArrays(labelsChunkedArray: floatChunkedArray, weightChunkedArrayOpt: Option[floatChunkedArray],
+                    initScoreChunkedArrayOpt: Option[doubleChunkedArray]): Unit = {
+    labelsChunkedArray.release()
+    weightChunkedArrayOpt.foreach(_.release())
+    initScoreChunkedArrayOpt.foreach(_.release())
+  }
+
+  def copyRowsToChunkedArrays(headRow: Row, rowsIter: Iterator[Row],
+                              denseDatasetAggregator: DenseDatasetAggregator): Unit = {
+    denseDatasetAggregator.addRows(Array(headRow).toIterator ++ rowsIter)
+  }
+
+  def copyRowsToSparseDataset(rowsIter: Iterator[Row],
+                              columnParams: ColumnParams,
+                              schema: StructType,
+                              sparseDatasetAggregator: SparseDatasetAggregator): Unit = {
+    val rows = rowsIter.toArray
+    val labels = rows.map(row => row.getDouble(schema.fieldIndex(columnParams.labelColumn)))
+    val rowsAsSparse = rows.map(row => row.get(schema.fieldIndex(columnParams.featuresColumn)) match {
+      case dense: DenseVector => dense.toSparse
+      case sparse: SparseVector => sparse
+    })
+    val weightsOpt = columnParams.weightColumn.map { col =>
+      rows.map(row => row.getDouble(schema.fieldIndex(col)))
+    }
+    val initScoresOpt = getInitScores(rows, columnParams.initScoreColumn, schema)
+    val groupColumnValues = ListBuffer[Row]()
+    rows.map(addGroupColumnRow(_, groupColumnValues, columnParams, schema))
+    sparseDatasetAggregator.addRows(labels, weightsOpt, initScoresOpt, rowsAsSparse, groupColumnValues)
+  }
+
+  def aggregateDenseStreamedData(rowsIter: Iterator[Row], columnParams: ColumnParams,
+                                 referenceDataset: Option[LightGBMDataset], schema: StructType,
+                                 log: Logger, trainParams: TrainParams): Option[LightGBMDataset] = {
+    val headRow = rowsIter.next()
+    val rowAsDoubleArray = getRowAsDoubleArray(headRow, columnParams, schema)
+    val numCols = rowAsDoubleArray.length
+    val chunkSize = trainParams.executionParams.chunkSize
+    val useSingleDataset = trainParams.executionParams.useSingleDatasetMode
+    if (useSingleDataset) {
+      SingletonDataset.setupDenseDatasetState(columnParams, chunkSize, numCols, schema)
+    }
+    val denseDatasetAggregator =
+      if (useSingleDataset) SingletonDataset.DenseDatasetState.get.get
+      else new DenseDatasetAggregator(columnParams, chunkSize, numCols, schema, false)
+    try {
+      copyRowsToChunkedArrays(headRow, rowsIter, denseDatasetAggregator)
+      // When using singleton dataset, wait for all tasks to finish copying the data
+      if (useSingleDataset) {
+        SingletonDataset.DoneSignal.await()
+      }
+      val numRows = denseDatasetAggregator.rowCount
+      val slotNames = getSlotNames(schema, columnParams.featuresColumn, numCols, trainParams)
+      log.info(s"LightGBM task generating dense dataset with $numRows rows and $numCols columns")
+      val dataset = Some(LightGBMUtils.generateDenseDataset(numRows, numCols,
+        denseDatasetAggregator.featuresChunkedArray,
+        referenceDataset, slotNames, trainParams, chunkSize))
+      dataset.get.addFloatField(denseDatasetAggregator.labelsChunkedArray,
+        "label", numRows)
+
+      denseDatasetAggregator.weightChunkedArrayOpt
+        .foreach(dataset.get.addFloatField(_, "weight", numRows))
+      denseDatasetAggregator.initScoreChunkedArrayOpt
+        .foreach(dataset.get.addDoubleField(_, "init_score", numRows))
+      val overrideGroupIndex = Some(0)
+      addGroupColumn(denseDatasetAggregator.groupColumnValues.toArray, columnParams.groupColumn, dataset,
+        numRows, schema, overrideGroupIndex)
+      dataset
+    } finally {
+      releaseArrays(denseDatasetAggregator.labelsChunkedArray,
+        denseDatasetAggregator.weightChunkedArrayOpt,
+        denseDatasetAggregator.initScoreChunkedArrayOpt)
+    }
+  }
+
+  def aggregateSparseStreamedData(rowsIter: Iterator[Row], columnParams: ColumnParams,
+                                  referenceDataset: Option[LightGBMDataset], schema: StructType,
+                                  log: Logger, trainParams: TrainParams): Option[LightGBMDataset] = {
+    val useSingleDataset = trainParams.executionParams.useSingleDatasetMode
+    if (useSingleDataset) {
+      SingletonDataset.setupSparseDatasetState()
+    }
+    val sparseDatasetAggregator =
+      if (useSingleDataset) SingletonDataset.SparseDatasetState.get.get
+      else new SparseDatasetAggregator(false)
+
+    copyRowsToSparseDataset(rowsIter, columnParams, schema, sparseDatasetAggregator)
+    // When using singleton dataset, wait for all tasks to finish copying the data
+    if (useSingleDataset) {
+      SingletonDataset.DoneSignal.await()
+    }
+    val numCols = sparseDatasetAggregator.featuresArray(0).size
+    val slotNames = getSlotNames(schema, columnParams.featuresColumn, numCols, trainParams)
+    val numRows = sparseDatasetAggregator.rowCount
+    log.info(s"LightGBM task generating sparse dataset with $numRows rows and $numCols columns")
+    val dataset = Some(LightGBMUtils.generateSparseDataset(sparseDatasetAggregator.featuresArray.toArray,
+      referenceDataset, slotNames, trainParams))
+
+    dataset.get.addFloatField(sparseDatasetAggregator.labelsArray.toArray, "label", numRows)
+    sparseDatasetAggregator.weightArrayOpt.foreach(weightArray =>
+      dataset.get.addFloatField(weightArray.toArray, "weight", numRows))
+    sparseDatasetAggregator.initScoreArrayOpt.foreach(initScoreArray =>
+      dataset.get.addDoubleField(initScoreArray.toArray, "init_score", numRows))
+    val overrideGroupIndex = Some(0)
+    addGroupColumn(sparseDatasetAggregator.groupColumnValuesArray.toArray,
+      columnParams.groupColumn, dataset, numRows, schema, overrideGroupIndex)
+    dataset
+  }
+
+  def validateGroupColumn(groupColumn: Option[String], schema: StructType): Unit = {
+    groupColumn.foreach { col =>
+      val datatype = schema.fields(schema.fieldIndex(col)).dataType
+
+      if (datatype != org.apache.spark.sql.types.IntegerType
+        && datatype != org.apache.spark.sql.types.LongType
+        && datatype != org.apache.spark.sql.types.StringType) {
+        throw new IllegalArgumentException(
+          s"group column $col must be of type Long, Int or String but is ${datatype.typeName}")
+      }
+    }
+  }
+
+  def getSlotNames(schema: StructType, featuresColumn: String, numCols: Int,
+                   trainParams: TrainParams): Option[Array[String]] = {
+    if (trainParams.featureNames.nonEmpty) {
+      Some(trainParams.featureNames)
+    } else {
+      val featuresSchema = schema.fields(schema.fieldIndex(featuresColumn))
+      val metadata = AttributeGroup.fromStructField(featuresSchema)
+      if (metadata.attributes.isEmpty) None
+      else if (metadata.attributes.get.isEmpty) None
+      else {
+        val colnames = (0 until numCols).map(_.toString).toArray
+        metadata.attributes.get.foreach {
+          case attr =>
+            attr.index.foreach(index => colnames(index) = attr.name.getOrElse(index.toString))
+        }
+        Some(colnames)
+      }
+    }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/dataset/SingletonDataset.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/dataset/SingletonDataset.scala
@@ -1,0 +1,60 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.ml.spark.lightgbm.dataset
+
+import java.util.concurrent.CountDownLatch
+
+import com.microsoft.ml.spark.io.http.SharedSingleton
+import com.microsoft.ml.spark.lightgbm.ColumnParams
+import org.apache.spark.sql.types.StructType
+
+object SingletonDataset {
+  var IsSparse: SharedSingleton[Option[Boolean]] = SharedSingleton { None }
+  def linkIsSparse(isSparse: Boolean): Unit = {
+    this.synchronized {
+      if (IsSparse.get == None) {
+        IsSparse = SharedSingleton {
+          Some(isSparse)
+        }
+      }
+    }
+  }
+
+  var DoneSignal: CountDownLatch = new CountDownLatch(0)
+  def incrementDoneSignal(): Unit = {
+    this.synchronized {
+      val count = DoneSignal.getCount().toInt
+      DoneSignal = new CountDownLatch(count + 1)
+    }
+  }
+
+  var DenseDatasetState: SharedSingleton[Option[DenseDatasetAggregator]] = SharedSingleton { None }
+  def setupDenseDatasetState(columnParams: ColumnParams, chunkSize: Int, numCols: Int, schema: StructType): Unit = {
+    this.synchronized {
+      if (DenseDatasetState.get == None) {
+        DenseDatasetState = SharedSingleton {
+          Some(new DenseDatasetAggregator(columnParams, chunkSize, numCols, schema, true))
+        }
+      }
+    }
+  }
+
+  var SparseDatasetState: SharedSingleton[Option[SparseDatasetAggregator]] = SharedSingleton { None }
+  def setupSparseDatasetState(): Unit = {
+    this.synchronized {
+      if (SparseDatasetState.get == None) {
+        SparseDatasetState = SharedSingleton {
+          Some(new SparseDatasetAggregator(true))
+        }
+      }
+    }
+  }
+
+  def resetSingletonDatasetState(): Unit = {
+    IsSparse = SharedSingleton { None }
+    DoneSignal = new CountDownLatch(0)
+    DenseDatasetState = SharedSingleton { None }
+    SparseDatasetState = SharedSingleton { None }
+  }
+}

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/params/LightGBMParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/params/LightGBMParams.scala
@@ -52,11 +52,19 @@ trait LightGBMExecutionParams extends Wrappable {
   def setTimeout(value: Double): this.type = set(timeout, value)
 
   val useBarrierExecutionMode = new BooleanParam(this, "useBarrierExecutionMode",
-    "Use new barrier execution mode in Beta testing, off by default.")
+    "Barrier execution mode which uses a barrier stage, off by default.")
   setDefault(useBarrierExecutionMode -> false)
 
   def getUseBarrierExecutionMode: Boolean = $(useBarrierExecutionMode)
   def setUseBarrierExecutionMode(value: Boolean): this.type = set(useBarrierExecutionMode, value)
+
+  val useSingleDatasetMode = new BooleanParam(this, "useSingleDatasetMode",
+    "Use single dataset execution mode to create a single native dataset per executor (singleton) " +
+      "to reduce memory and communication overhead. Note this is disabled when running spark in local mode.")
+  setDefault(useSingleDatasetMode -> false)
+
+  def getUseSingleDatasetMode: Boolean = $(useSingleDatasetMode)
+  def setUseSingleDatasetMode(value: Boolean): this.type = set(useSingleDatasetMode, value)
 
   val numBatches = new IntParam(this, "numBatches",
     "If greater than 0, splits data into separate batches during training")

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/params/TrainParams.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/params/TrainParams.scala
@@ -152,7 +152,8 @@ case class DartModeParams(dropRate: Double, maxDrop: Int, skipDrop: Double,
   * @param matrixType Advanced parameter to specify whether the native lightgbm matrix
   *                   constructed should be sparse or dense.
   */
-case class ExecutionParams(chunkSize: Int, matrixType: String) extends Serializable
+case class ExecutionParams(chunkSize: Int, matrixType: String,
+                           useSingleDatasetMode: Boolean) extends Serializable
 
 /** Defines parameters related to the lightgbm objective function.
   *

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split2/VerifyLightGBMRanker.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split2/VerifyLightGBMRanker.scala
@@ -5,7 +5,8 @@ package com.microsoft.ml.spark.lightgbm.split2
 
 import com.microsoft.ml.spark.core.test.benchmarks.{Benchmarks, DatasetUtils}
 import com.microsoft.ml.spark.core.test.fuzzing.{EstimatorFuzzing, TestObject}
-import com.microsoft.ml.spark.lightgbm.TrainUtils.CardinalityTypes._
+import com.microsoft.ml.spark.lightgbm.dataset.DatasetUtils.CardinalityTypes._
+import com.microsoft.ml.spark.lightgbm.dataset.{DatasetUtils => CardinalityUtils}
 import com.microsoft.ml.spark.lightgbm.split1.LightGBMTestUtils
 import com.microsoft.ml.spark.lightgbm.{LightGBMRanker, LightGBMRankerModel, LightGBMUtils, TrainUtils}
 import org.apache.spark.SparkException
@@ -128,13 +129,13 @@ class VerifyLightGBMRanker extends Benchmarks with EstimatorFuzzing[LightGBMRank
   }
 
   test("verify cardinality counts: int") {
-    val counts = TrainUtils.countCardinality(Seq(1, 1, 2, 2, 2, 3))
+    val counts = CardinalityUtils.countCardinality(Seq(1, 1, 2, 2, 2, 3))
 
     counts shouldBe Seq(2, 3, 1)
   }
 
   test("verify cardinality counts: string") {
-    val counts = TrainUtils.countCardinality(Seq("a", "a", "b", "b", "b", "c"))
+    val counts = CardinalityUtils.countCardinality(Seq("a", "a", "b", "b", "b", "c"))
 
     counts shouldBe Seq(2, 3, 1)
   }


### PR DESCRIPTION
Adding single (or "singleton") dataset mode to lightgbm learners.
User can enable this new mode by setting the parameter useSingleDatasetMode=True (it is false by default).
In this mode, each executor creates a single LightGBMDataset.  By default, currently each task within an executor creates a dataset:

![image](https://user-images.githubusercontent.com/24683184/120339283-f8e2f700-c2c2-11eb-8163-65cf810be694.png)

In this PR, a new mode is added to only create one dataset per executor:

![image](https://user-images.githubusercontent.com/24683184/120339351-0ac49a00-c2c3-11eb-9543-2a42e4361031.png)

This means that there is lower network communication overhead since fewer nodes are initialized and more parallelization is done within the machine in the native code with default number of threads.  This also seems to reduce memory usage significantly for some datasets.

Note in most cluster configurations there is usually only one executor per machine anyway.

In performance tests, we've found this mode sometimes outperforms the default in certain scenarios, both in terms of memory and execution time.

On a sparse dataset with 9 GB of data and large parameter values (num_leaves=768, num_trees=1000, min_data_in_leaf=15000, max_bin=512) and 5 machines with 8 cores and 28 GB of RAM, runtime was 17.54 minutes with this new mode. When specifying tasks=5 it took 106 minutes and in default mode it failed with OOM.  

However in other scenarios the default mode is much faster.
On dense Higgs dataset (4GB) with default parameters and 8 workers with 14 GB memory, 4 cores each the default run took 54 seconds but new single dataset mode took 2.2 minutes, twice as slow.

For this reason we will keep this mode as non-default for now as we continue to do more benchmarking/experimentation.

