### PR TITLE
fix: [Workaround] CNTKModel does not output correct result

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/cntk/CNTKModel.scala
+++ b/src/main/scala/com/microsoft/ml/spark/cntk/CNTKModel.scala
@@ -534,7 +534,8 @@ class CNTKModel(override val uid: String) extends Model[CNTKModel] with ComplexP
       val unbatchedDF = if (getBatchInput) {
         // TODO: The cache call is a workaround for issue 1075:
         //  https://github.com/Azure/mmlspark/issues/1075
-        new FlattenBatch().transform(droppedDF.cache())
+        val cacheAttempted = if (droppedDF.isStreaming) droppedDF else droppedDF.cache()
+        new FlattenBatch().transform(cacheAttempted)
       } else {
         droppedDF
       }

--- a/src/main/scala/com/microsoft/ml/spark/cntk/CNTKModel.scala
+++ b/src/main/scala/com/microsoft/ml/spark/cntk/CNTKModel.scala
@@ -532,7 +532,7 @@ class CNTKModel(override val uid: String) extends Model[CNTKModel] with ComplexP
       val droppedDF = outputDF.drop(outputDF.columns.filter(_.startsWith(coercionPrefix)): _*)
 
       val unbatchedDF = if (getBatchInput) {
-        new FlattenBatch().transform(droppedDF)
+        new FlattenBatch().transform(droppedDF.cache())
       } else {
         droppedDF
       }

--- a/src/main/scala/com/microsoft/ml/spark/cntk/CNTKModel.scala
+++ b/src/main/scala/com/microsoft/ml/spark/cntk/CNTKModel.scala
@@ -532,6 +532,8 @@ class CNTKModel(override val uid: String) extends Model[CNTKModel] with ComplexP
       val droppedDF = outputDF.drop(outputDF.columns.filter(_.startsWith(coercionPrefix)): _*)
 
       val unbatchedDF = if (getBatchInput) {
+        // TODO: The cache call is a workaround for issue 1075:
+        //  https://github.com/Azure/mmlspark/issues/1075
         new FlattenBatch().transform(droppedDF.cache())
       } else {
         droppedDF


### PR DESCRIPTION
Workaround for #1075 : CNTKModel does not output correct result for ResNet50 model when running on Databricks.
@mhamilton723 discovered adding a cache call works around the issue.