### PR TITLE
feat: TextAnalytics SDK connector POC - with language detection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,10 @@ libraryDependencies ++= Seq(
   "org.openpnp" % "opencv" % "3.2.0-1",
   "com.jcraft" % "jsch" % "0.1.54",
   "com.microsoft.cognitiveservices.speech" % "client-sdk" % "1.14.0",
+  // TA SDK (latest preview) https://mvnrepository.com/artifact/com.azure/azure-ai-textanalytics/5.1.0-beta.7
+  // |
+  // V
+  "com.azure" % "azure-ai-textanalytics" % "5.1.0-beta.7",
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
   "org.apache.httpcomponents" % "httpmime" % "4.5.6",
   "com.microsoft.ml.lightgbm" % "lightgbmlib" % "3.2.110",

--- a/src/main/scala/com/microsoft/ml/spark/cognitive/CognitiveServiceBase.scala
+++ b/src/main/scala/com/microsoft/ml/spark/cognitive/CognitiveServiceBase.scala
@@ -138,6 +138,19 @@ trait HasSubscriptionKey extends HasServiceParams {
 
 }
 
+trait HasEndpoint extends HasServiceParams {
+  val endpoint = new ServiceParam[String](
+    this, name="endpoint", "resource endpoint")
+
+  def getEndpoint: String = getScalarParam(endpoint)
+
+  def setEndpoint(v: String): this.type  = setScalarParam(endpoint, v)
+
+  def getEndpointKeyCol: String = getVectorParam(endpoint)
+
+  def setEndpointKeyCol(v: String): this.type = setVectorParam(endpoint, v)
+}
+
 object URLEncodingUtils {
 
   private case class NameValuePairInternal(t: (String, String)) extends NameValuePair {

--- a/src/main/scala/com/microsoft/ml/spark/cognitive/TextAnalyticsSDK.scala
+++ b/src/main/scala/com/microsoft/ml/spark/cognitive/TextAnalyticsSDK.scala
@@ -1,0 +1,131 @@
+package com.microsoft.ml.spark.cognitive
+
+import com.azure.ai.textanalytics.models.TextAnalyticsRequestOptions
+import com.azure.ai.textanalytics.{TextAnalyticsClient, TextAnalyticsClientBuilder}
+import com.azure.core.credential.AzureKeyCredential
+import com.microsoft.ml.spark.core.contracts.{HasConfidenceScoreCol, HasInputCol}
+import com.microsoft.ml.spark.core.schema.SparkBindings
+import com.microsoft.ml.spark.io.http.HasErrorCol
+import com.microsoft.ml.spark.logging.BasicLogging
+import org.apache.spark.injections.UDFUtils
+import org.apache.spark.ml.param.{Param, ParamMap}
+import org.apache.spark.ml.util.Identifiable._
+import org.apache.spark.ml.{ComplexParamsReadable, ComplexParamsWritable, Transformer}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{DataTypes, StructType}
+import org.apache.spark.sql.{DataFrame, Dataset}
+
+import scala.collection.JavaConverters._
+
+abstract class TextAnalyticsSDKBase[T](val textAnalyticsOptions: Option[TextAnalyticsRequestOptions] = None)
+  extends Transformer
+  with HasInputCol with HasErrorCol
+  with HasEndpoint with HasSubscriptionKey
+  with ComplexParamsWritable with BasicLogging {
+
+  protected val invokeTextAnalytics: String => TAResponseV4[T]
+
+  protected def outputSchema: StructType
+
+  protected lazy val textAnalyticsClient: TextAnalyticsClient =
+    new TextAnalyticsClientBuilder()
+      .credential(new AzureKeyCredential(getSubscriptionKey))
+      .endpoint(getEndpoint)
+      .buildClient()
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    logTransform[DataFrame]({
+      val invokeTextAnalyticsUdf = UDFUtils.oldUdf(invokeTextAnalytics, outputSchema)
+      val inputColNames = dataset.columns.mkString(",")
+      dataset.withColumn("Out", invokeTextAnalyticsUdf(col($(inputCol))))
+        .select(inputColNames, "Out.result.*", "Out.error.*", "Out.statistics.*", "Out.*")
+        .drop("result", "error", "statistics")
+    })
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    // Validate input schema
+    val inputType = schema($(inputCol)).dataType
+    require(inputType.equals(DataTypes.StringType), s"The input column must be of type String, but got $inputType")
+
+    // Making sure input schema doesn't overlap with output schema
+    val fieldsIntersection = schema.map(sf => sf.name.toLowerCase)
+      .intersect(outputSchema.map(sf => sf.name.toLowerCase()))
+    require(fieldsIntersection.isEmpty, s"Input schema overlaps with transformer output schema. " +
+      s"Rename the following input columns: [${fieldsIntersection.mkString(", ")}]")
+
+    // Creating output schema (input schema + output schema)
+    val consolidatedSchema = (schema ++ outputSchema).toSet
+    StructType(consolidatedSchema.toSeq)
+  }
+
+  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+}
+
+object TextAnalyticsLanguageDetection extends ComplexParamsReadable[TextAnalyticsLanguageDetection]
+
+class TextAnalyticsLanguageDetection(override val textAnalyticsOptions: Option[TextAnalyticsRequestOptions] = None,
+                                     override val uid: String = randomUID("TextAnalyticsLanguageDetection"))
+  extends TextAnalyticsSDKBase[DetectedLanguageV4](textAnalyticsOptions)
+  with HasConfidenceScoreCol {
+  logClass()
+
+  /**
+   * Params for optional input column names.
+   */
+  // Country Hint
+  final val countryHintCol: Param[String] = new Param[String](this, "countryHintCol", "country hint column name")
+
+  final def getCountryHintCol: String = $(countryHintCol)
+
+  final def setCountryHintCol(value: String): this.type = set(countryHintCol, value)
+  setDefault(countryHintCol -> "CountryHint")
+
+  override def outputSchema: StructType = DetectLanguageResponseV4.schema
+
+  override protected val invokeTextAnalytics: String => TAResponseV4[DetectedLanguageV4] = (text: String) =>
+    {
+      val detectLanguageResultCollection = textAnalyticsClient.detectLanguageBatch(
+        Seq(text).asJava, null, textAnalyticsOptions.orNull)
+      val detectLanguageResult = detectLanguageResultCollection.asScala.head
+
+      val languageResult = if (detectLanguageResult.isError) {
+        None
+      } else {
+        Some(DetectedLanguageV4(
+          detectLanguageResult.getPrimaryLanguage.getName,
+          detectLanguageResult.getPrimaryLanguage.getIso6391Name,
+          detectLanguageResult.getPrimaryLanguage.getConfidenceScore))
+      }
+
+      val error = if (detectLanguageResult.isError) {
+        val error = detectLanguageResult.getError
+        Some(TAErrorV4(error.getErrorCode.toString, error.getMessage, error.getTarget))
+      } else {
+        None
+      }
+
+      val stats = Option(detectLanguageResult.getStatistics) match {
+        case Some(s) => Some(DocumentStatistics(s.getCharacterCount, s.getTransactionCount))
+        case None => None
+      }
+
+      TAResponseV4[DetectedLanguageV4](
+        languageResult,
+        error,
+        stats,
+        Some(detectLanguageResultCollection.getModelVersion))
+    }
+}
+
+object DetectLanguageResponseV4 extends SparkBindings[TAResponseV4[DetectedLanguageV4]]
+
+case class TAResponseV4[T](result: Option[T],
+                           error: Option[TAErrorV4],
+                           statistics: Option[DocumentStatistics],
+                           modelVersion: Option[String])
+
+case class TAErrorV4(errorCode: String, errorMessage: String, target: String)
+
+case class DetectedLanguageV4(name: String, iso6391Name: String, confidenceScore: Double)
+

--- a/src/main/scala/com/microsoft/ml/spark/core/contracts/Params.scala
+++ b/src/main/scala/com/microsoft/ml/spark/core/contracts/Params.scala
@@ -206,3 +206,20 @@ trait HasGroupCol extends Params {
   /** @group getParam */
   def getGroupCol: String = $(groupCol)
 }
+
+trait HasConfidenceScoreCol extends Params {
+  /** The name of the confidence score column
+   *
+   * @group param
+   */
+  val confidenceScoreCol =
+    new Param[String](this, "confidenceScoreCol",
+      "Confidence score, usually a value between 0-1. Higher value implies higher model confidence.")
+
+  /** @group setParam */
+  def setConfidenceScoreCol(value: String): this.type = set(confidenceScoreCol, value)
+
+  /** @group getParam */
+  def getConfidenceScoreCol: String = $(confidenceScoreCol)
+  setDefault(confidenceScoreCol -> "ConfidenceScore")
+}

--- a/src/main/scala/com/microsoft/ml/spark/io/http/SimpleHTTPTransformer.scala
+++ b/src/main/scala/com/microsoft/ml/spark/io/http/SimpleHTTPTransformer.scala
@@ -25,7 +25,7 @@ trait HasErrorCol extends Params {
   def setErrorCol(v: String): this.type = set(errorCol, v)
 
   def getErrorCol: String = $(errorCol)
-
+  setDefault(errorCol -> "Error")
 }
 
 object ErrorUtils extends Serializable {

--- a/src/test/scala/com/microsoft/ml/spark/cognitive/split1/TextAnalyticsSDKSuite.scala
+++ b/src/test/scala/com/microsoft/ml/spark/cognitive/split1/TextAnalyticsSDKSuite.scala
@@ -1,0 +1,36 @@
+package com.microsoft.ml.spark.cognitive.split1
+
+import com.azure.ai.textanalytics.models.TextAnalyticsRequestOptions
+import com.microsoft.ml.spark.cognitive._
+import com.microsoft.ml.spark.core.test.base.TestBase
+import org.apache.spark.ml.param.DataFrameEquality
+import org.apache.spark.sql.DataFrame
+
+class TextAnalyticsSDKSuite extends TestBase with DataFrameEquality with TextKey {
+  import spark.implicits._
+
+  lazy val df: DataFrame = Seq(
+    "Hello World",
+    "Bonjour tout le monde",
+    "La carretera estaba atascada. Había mucho tráfico el día de ayer.",
+    ":) :( :D"
+  ).toDF("text2")
+
+  val options: Option[TextAnalyticsRequestOptions] = Some(new TextAnalyticsRequestOptions()
+    .setIncludeStatistics(true))
+
+  lazy val detector: TextAnalyticsLanguageDetection = new TextAnalyticsLanguageDetection(options)
+    .setSubscriptionKey("91475c1eb6e14ede85d6a7bf491dacc3")
+    .setEndpoint("https://assafiwus.cognitiveservices.azure.com/")
+    .setInputCol("text2")
+
+  test("Basic Usage") {
+    val replies = detector.transform(df)
+      .select("name", "iso6391Name")
+      .collect()
+//      .select(detector.getPrimaryDetectedLanguageNameCol)
+//      .collect().toList
+    assert(replies(0).getString(0) == "English" && replies(2).getString(0) == "Spanish")
+    assert(replies(0).getString(1) == "en" && replies(2).getString(1) == "es")
+  }
+}

--- a/src/test/scala/com/microsoft/ml/spark/cognitive/split1/TextAnalyticsSDKSuite.scala
+++ b/src/test/scala/com/microsoft/ml/spark/cognitive/split1/TextAnalyticsSDKSuite.scala
@@ -20,8 +20,8 @@ class TextAnalyticsSDKSuite extends TestBase with DataFrameEquality with TextKey
     .setIncludeStatistics(true))
 
   lazy val detector: TextAnalyticsLanguageDetection = new TextAnalyticsLanguageDetection(options)
-    .setSubscriptionKey("91475c1eb6e14ede85d6a7bf491dacc3")
-    .setEndpoint("https://assafiwus.cognitiveservices.azure.com/")
+    .setSubscriptionKey("enter-key")
+    .setEndpoint("endpoint")
     .setInputCol("text2")
 
   test("Basic Usage") {

--- a/src/test/scala/com/microsoft/ml/spark/cognitive/split1/TextAnalyticsSDKSuite.scala
+++ b/src/test/scala/com/microsoft/ml/spark/cognitive/split1/TextAnalyticsSDKSuite.scala
@@ -20,16 +20,15 @@ class TextAnalyticsSDKSuite extends TestBase with DataFrameEquality with TextKey
     .setIncludeStatistics(true))
 
   lazy val detector: TextAnalyticsLanguageDetection = new TextAnalyticsLanguageDetection(options)
-    .setSubscriptionKey("enter-key")
-    .setEndpoint("endpoint")
+    .setSubscriptionKey(textKey)
+    .setEndpoint("https://eastus.api.cognitive.microsoft.com/")
     .setInputCol("text2")
 
   test("Basic Usage") {
     val replies = detector.transform(df)
       .select("name", "iso6391Name")
       .collect()
-//      .select(detector.getPrimaryDetectedLanguageNameCol)
-//      .collect().toList
+
     assert(replies(0).getString(0) == "English" && replies(2).getString(0) == "Spanish")
     assert(replies(0).getString(1) == "en" && replies(2).getString(1) == "es")
   }


### PR DESCRIPTION
A small weekend experiment to try and make things a little bit clearer for the project.
This commit includes a very rough sketch base class and a sub-class implementation for language detection. 

One thing I noticed is that the Java SDK data classes are mostly _not_ ```@Serializable``` which makes it impossible ATM to reuse as-is. I've asked the SDK team to consider adding this in the next SDK version. In the meantime, we'll just need to create mirror scala case classes.

This is mostly an example as things are pretty rough. For example, most classes are in a single file, missing a bunch of schema validation, and I only included the most basic test.