### PR TITLE
fix: explainer bug when targetClassesCol is set.

### DIFF
--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/ImageLIME.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/ImageLIME.scala
@@ -89,7 +89,8 @@ class ImageLIME(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        stateCol: String,
-                                       distanceCol: String
+                                       distanceCol: String,
+                                       targetClassesCol: String
                                       ): DataFrame = {
 
     val samplingUdf = df.schema(getInputCol).dataType match {
@@ -106,7 +107,8 @@ class ImageLIME(override val uid: String)
         col(idCol),
         col(samplesCol).getField(distanceField).alias(distanceCol),
         col(samplesCol).getField(stateField).alias(stateCol),
-        col(samplesCol).getField(sampleField).alias(getInputCol)
+        col(samplesCol).getField(sampleField).alias(getInputCol),
+        col(targetClassesCol)
       )
   }
 

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/ImageSHAP.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/ImageSHAP.scala
@@ -89,7 +89,8 @@ class ImageSHAP(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        coalitionCol: String,
-                                       weightCol: String): DataFrame = {
+                                       weightCol: String,
+                                       targetClassesCol: String): DataFrame = {
     val samplingUdf = df.schema(getInputCol).dataType match {
       case BinaryType =>
         this.binarySamplesUdf
@@ -104,7 +105,8 @@ class ImageSHAP(override val uid: String)
         col(idCol),
         col(samplesCol).getField(sampleField).alias(getInputCol),
         col(samplesCol).getField(coalitionField).alias(coalitionCol),
-        col(samplesCol).getField(weightField).alias(weightCol)
+        col(samplesCol).getField(weightField).alias(weightCol),
+        col(targetClassesCol)
       )
   }
 

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/LocalExplainer.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/LocalExplainer.scala
@@ -3,18 +3,23 @@
 
 package com.microsoft.ml.spark.explainers
 
-import org.apache.spark.ml.linalg.SQLDataTypes.MatrixType
+import com.microsoft.ml.spark.core.utils.SlicerFunctions
+import org.apache.spark.injections.UDFUtils
+import org.apache.spark.ml.linalg.SQLDataTypes.{MatrixType, VectorType}
+import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.shared.HasOutputCol
 import org.apache.spark.ml.{ComplexParamsWritable, Transformer}
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.functions.{array, col}
+import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, NumericType, StructType}
 
 trait LocalExplainer
   extends Transformer with HasExplainTarget with HasOutputCol with HasModel with ComplexParamsWritable {
 
   final def setOutputCol(value: String): this.type = this.set(outputCol, value)
 
-  protected def validateSchema(inputSchema: StructType): Unit = {
+  protected override def validateSchema(inputSchema: StructType): Unit = {
+    super.validateSchema(inputSchema)
     if (inputSchema.fieldNames.contains(getOutputCol)) {
       throw new IllegalArgumentException(s"Input schema already has column $getOutputCol")
     }
@@ -26,6 +31,38 @@ trait LocalExplainer
   }
 
   protected def preprocess(df: DataFrame): DataFrame = df
+
+  /**
+   * This function supports a variety of target column types:
+   * - NumericType: in the case of a regression model
+   * - VectorType: in the case of a typical Spark ML classification model with probability output
+   * - ArrayType(NumericType): in the case where the output was converted to an array of numeric types.
+   * - MapType(IntegerType, NumericType): this is to support ZipMap type of output for sklearn models via ONNX runtime.
+   */
+  private[explainers] def extractTarget(schema: StructType, targetClassesCol: String): Column = {
+    val toVector = UDFUtils.oldUdf(
+      (values: Seq[Double]) => Vectors.dense(values.toArray),
+      VectorType
+    )
+
+    val target = schema(getTargetCol).dataType match {
+      case _: NumericType =>
+        toVector(array(col(getTargetCol)))
+      case VectorType =>
+        SlicerFunctions.vectorSlicer(col(getTargetCol), col(targetClassesCol))
+      case ArrayType(elementType: NumericType, _) =>
+        SlicerFunctions.arraySlicer(elementType)(col(getTargetCol), col(targetClassesCol))
+      case MapType(_: IntegerType, valueType: NumericType, _) =>
+        SlicerFunctions.mapSlicer(valueType)(col(getTargetCol), col(targetClassesCol))
+      case other =>
+        throw new IllegalArgumentException(
+          s"Only numeric types, vector type, array of numeric types and map types with numeric value type " +
+            s"are supported as target column. The current type is $other."
+        )
+    }
+
+    target
+  }
 }
 
 object LocalExplainer {

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/TabularLIME.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/TabularLIME.scala
@@ -42,7 +42,8 @@ class TabularLIME(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        stateCol: String,
-                                       distanceCol: String): DataFrame = {
+                                       distanceCol: String,
+                                       targetClassesCol: String): DataFrame = {
 
     val numSamples = this.getNumSamples
 
@@ -71,6 +72,7 @@ class TabularLIME(override val uid: String)
         col(idCol),
         col(samplesCol).getField(distanceField).alias(distanceCol),
         col(samplesCol).getField(stateField).alias(stateCol),
+        col(targetClassesCol),
         expr(s"$samplesCol.$sampleField.*")
       )
   }

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/TabularSHAP.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/TabularSHAP.scala
@@ -29,11 +29,12 @@ class TabularSHAP(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        coalitionCol: String,
-                                       weightCol: String): DataFrame = {
+                                       weightCol: String,
+                                       targetClassesCol: String): DataFrame = {
     val instanceCol = DatasetExtensions.findUnusedColumnName("instance", df)
     val backgroundCol = DatasetExtensions.findUnusedColumnName("background", df)
 
-    val instances = df.select(col(idCol), struct(getInputCols.map(col): _*).alias(instanceCol))
+    val instances = df.select(col(idCol), col(targetClassesCol), struct(getInputCols.map(col): _*).alias(instanceCol))
     val background = this.getBackgroundData
       .select(struct(getInputCols.map(col): _*).alias(backgroundCol))
 
@@ -70,7 +71,8 @@ class TabularSHAP(override val uid: String)
         col(idCol),
         expr(s"$samplesCol.$sampleField.*"),
         col(samplesCol).getField(coalitionField).alias(coalitionCol),
-        col(samplesCol).getField(weightField).alias(weightCol)
+        col(samplesCol).getField(weightField).alias(weightCol),
+        col(targetClassesCol)
       )
   }
 

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/TextLIME.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/TextLIME.scala
@@ -36,7 +36,8 @@ class TextLIME(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        stateCol: String,
-                                       distanceCol: String
+                                       distanceCol: String,
+                                       targetClassesCol: String
                                       ): DataFrame = {
     val (numSamples, samplingFraction) = (this.getNumSamples, this.getSamplingFraction)
 
@@ -62,7 +63,8 @@ class TextLIME(override val uid: String)
         col(idCol),
         col(samplesCol).getField(distanceField).alias(distanceCol),
         col(samplesCol).getField(stateField).alias(stateCol),
-        col(samplesCol).getField(sampleField).alias(getInputCol)
+        col(samplesCol).getField(sampleField).alias(getInputCol),
+        col(targetClassesCol)
       )
   }
 

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/TextSHAP.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/TextSHAP.scala
@@ -35,7 +35,8 @@ class TextSHAP(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        coalitionCol: String,
-                                       weightCol: String): DataFrame = {
+                                       weightCol: String,
+                                       targetClassesCol: String): DataFrame = {
     val numSamplesOpt = this.getNumSamplesOpt
 
     val infWeightVal = this.getInfWeight
@@ -61,7 +62,8 @@ class TextSHAP(override val uid: String)
         col(idCol),
         col(samplesCol).getField(sampleField).alias(getInputCol),
         col(samplesCol).getField(coalitionField).alias(coalitionCol),
-        col(samplesCol).getField(weightField).alias(weightCol)
+        col(samplesCol).getField(weightField).alias(weightCol),
+        col(targetClassesCol)
       )
   }
 

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/VectorLIME.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/VectorLIME.scala
@@ -32,7 +32,8 @@ class VectorLIME(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        stateCol: String,
-                                       distanceCol: String): DataFrame = {
+                                       distanceCol: String,
+                                       targetClassesCol: String): DataFrame = {
     val numSamples = this.getNumSamples
 
     val featureStats = this.createFeatureStats(this.getBackgroundData)
@@ -54,7 +55,8 @@ class VectorLIME(override val uid: String)
         col(idCol),
         col(samplesCol).getField(distanceField).alias(distanceCol),
         col(samplesCol).getField(stateField).alias(stateCol),
-        col(samplesCol).getField(sampleField).alias(getInputCol)
+        col(samplesCol).getField(sampleField).alias(getInputCol),
+        col(targetClassesCol)
       )
   }
 

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/VectorSHAP.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/VectorSHAP.scala
@@ -31,11 +31,12 @@ class VectorSHAP(override val uid: String)
   override protected def createSamples(df: DataFrame,
                                        idCol: String,
                                        coalitionCol: String,
-                                       weightCol: String): DataFrame = {
+                                       weightCol: String,
+                                       targetClassesCol: String): DataFrame = {
     val instanceCol = DatasetExtensions.findUnusedColumnName("instance", df)
     val backgroundCol = DatasetExtensions.findUnusedColumnName("background", df)
 
-    val instances = df.select(col(idCol), col(getInputCol).alias(instanceCol))
+    val instances = df.select(col(idCol), col(targetClassesCol), col(getInputCol).alias(instanceCol))
     val background = this.getBackgroundData
       .select(col(getInputCol).alias(backgroundCol))
 
@@ -63,7 +64,8 @@ class VectorSHAP(override val uid: String)
         col(idCol),
         col(samplesCol).getField(sampleField).alias(getInputCol),
         col(samplesCol).getField(coalitionField).alias(coalitionCol),
-        col(samplesCol).getField(weightField).alias(weightCol)
+        col(samplesCol).getField(weightField).alias(weightCol),
+        col(targetClassesCol)
       )
   }
 

--- a/core/src/test/scala/com/microsoft/ml/spark/explainers/split1/HasExplainTargetSuite.scala
+++ b/core/src/test/scala/com/microsoft/ml/spark/explainers/split1/HasExplainTargetSuite.scala
@@ -18,8 +18,7 @@ class HasExplainTargetSuite extends TestBase {
     // array of Int
     val target1 = LocalExplainer.LIME.vector
       .setTargetCol("label1")
-      .setTargetClasses(Array(0, 2))
-      .getExplainTarget(df.schema)
+      .extractTarget(df.schema, "targets")
 
     val Tuple1(v1) = df.select(target1).as[Tuple1[Vector]].head
     assert(v1 == Vectors.dense(1d, 3d))
@@ -27,8 +26,7 @@ class HasExplainTargetSuite extends TestBase {
     // vector
     val target2 = LocalExplainer.LIME.vector
       .setTargetCol("label2")
-      .setTargetClasses(Array(0, 2))
-      .getExplainTarget(df.schema)
+      .extractTarget(df.schema, "targets")
 
     val Tuple1(v2) = df.select(target2).as[Tuple1[Vector]].head
     assert(v2 == Vectors.dense(1d, 3d))
@@ -36,19 +34,9 @@ class HasExplainTargetSuite extends TestBase {
     // Map of Int -> Float
     val target3 = LocalExplainer.LIME.vector
       .setTargetCol("label3")
-      .setTargetClasses(Array(0, 2))
-      .getExplainTarget(df.schema)
+      .extractTarget(df.schema, "targets")
 
     val Tuple1(v3) = df.select(target3).as[Tuple1[Vector]].head
     assert(v3 == Vectors.dense(1d, 3d))
-
-    // Dynamically retrieve targets
-    val target4 = LocalExplainer.LIME.vector
-      .setTargetCol("label2")
-      .setTargetClassesCol("targets")
-      .getExplainTarget(df.schema)
-
-    val Tuple1(v4) = df.select(target4).as[Tuple1[Vector]].head
-    assert(v4 == Vectors.dense(1d, 3d))
   }
 }


### PR DESCRIPTION
Cause: currently, the column that contains the target classes is computed from the model transform step, but instead it should be carried from the original dataframe to be explained (before createSamples step).