### PR TITLE
fix: fix Guava version issue in Azure Synapse and Databricks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ val extraDependencies = Seq(
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
   "org.apache.httpcomponents" % "httpmime" % "4.5.6",
   "com.linkedin.isolation-forest" %% "isolation-forest_3.0.0" % "1.0.1",
+  "com.google.guava" % "guava" % "28.0-jre",
 ).map(d => d excludeAll (excludes: _*))
 val dependencies = coreDependencies ++ extraDependencies
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ val extraDependencies = Seq(
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
   "org.apache.httpcomponents" % "httpmime" % "4.5.6",
   "com.linkedin.isolation-forest" %% "isolation-forest_3.0.0" % "1.0.1",
-  "com.google.guava" % "guava" % "28.0-jre",
 ).map(d => d excludeAll (excludes: _*))
 val dependencies = coreDependencies ++ extraDependencies
 

--- a/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.types.StructType
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{Awaitable, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
+import scala.reflect.internal.util.ScalaClassLoader
 import scala.util.control.NonFatal
 
 /** Tunes model hyperparameters
@@ -95,7 +96,8 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
   private def getExecutionContext: ExecutionContext = {
     getParallelism match {
       case 1 =>
-        ExecutionContext.fromExecutor(MoreExecutors.directExecutor())
+        val executorService = MoreExecutors.newDirectExecutorService()
+        ExecutionContext.fromExecutorService(executorService)
       case _ =>
         val keepAliveSeconds = 60L
         val prefix = s"${this.getClass.getSimpleName}-thread-pool"

--- a/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
@@ -95,7 +95,7 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
   private def getExecutionContext: ExecutionContext = {
     getParallelism match {
       case 1 =>
-        ExecutionContext.fromExecutorService(MoreExecutors.sameThreadExecutor())
+        ExecutionContext.fromExecutor(MoreExecutors.directExecutor())
       case _ =>
         val keepAliveSeconds = 60L
         val prefix = s"${this.getClass.getSimpleName}-thread-pool"

--- a/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
@@ -96,12 +96,11 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
   private def getExecutionContext: ExecutionContext = {
     getParallelism match {
       case 1 =>
-        // val executorService = MoreExecutors.sameThreadExecutor()
         val classPath = "com.google.common.util.concurrent.MoreExecutors"
         val funcName = "sameThreadExecutor"
         val c =  ScalaClassLoader(getClass.getClassLoader).tryToLoadClass(classPath)
-        val method = c.getClass.getMethod(funcName)
-        val executorService: ExecutorService = method.invoke(c).asInstanceOf[ExecutorService]
+        val method = c.get.getMethod(funcName)
+        val executorService = method.invoke(c.get).asInstanceOf[ExecutorService]
         ExecutionContext.fromExecutorService(executorService)
       case _ =>
         val keepAliveSeconds = 60L

--- a/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
@@ -106,7 +106,8 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
             c.get.getMethod(funcNameNew)
           }
           catch {
-            case ex: NoSuchMethodError => c.get.getMethod(funcNameOld)
+            case _: NoSuchMethodError => c.get.getMethod(funcNameOld)
+            case _: NoSuchMethodException => c.get.getMethod(funcNameOld)
           }
         }
         val executorService = method.invoke(c.get).asInstanceOf[ExecutorService]

--- a/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
@@ -106,7 +106,7 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
             c.get.getMethod(funcNameNew)
           }
           catch {
-            case ex: NoSuchMethodException => c.get.getMethod(funcNameOld)
+            case ex: NoSuchMethodError => c.get.getMethod(funcNameOld)
           }
         }
         val executorService = method.invoke(c.get).asInstanceOf[ExecutorService]

--- a/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
@@ -96,7 +96,7 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
   private def getExecutionContext: ExecutionContext = {
     getParallelism match {
       case 1 =>
-        val executorService = MoreExecutors.newDirectExecutorService()
+        val executorService = MoreExecutors.sameThreadExecutor()
         ExecutionContext.fromExecutorService(executorService)
       case _ =>
         val keepAliveSeconds = 60L

--- a/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/automl/TuneHyperparameters.scala
@@ -96,7 +96,12 @@ class TuneHyperparameters(override val uid: String) extends Estimator[TuneHyperp
   private def getExecutionContext: ExecutionContext = {
     getParallelism match {
       case 1 =>
-        val executorService = MoreExecutors.sameThreadExecutor()
+        // val executorService = MoreExecutors.sameThreadExecutor()
+        val classPath = "com.google.common.util.concurrent.MoreExecutors"
+        val funcName = "sameThreadExecutor"
+        val c =  ScalaClassLoader(getClass.getClassLoader).tryToLoadClass(classPath)
+        val method = c.getClass.getMethod(funcName)
+        val executorService: ExecutorService = method.invoke(c).asInstanceOf[ExecutorService]
         ExecutionContext.fromExecutorService(executorService)
       case _ =>
         val keepAliveSeconds = 60L


### PR DESCRIPTION
Azure Synapse updated Guava to version 28.0

MoreExecutors.sameExecutorService() are not supported since Guava version >= 18
we should use this method: MoreExecutors.newDirectExecutorService()

but databricks use Guava version < 18, which don't contains MoreExecutors.newDirectExecutorService().

Therefore, I used reflection to load class "MoreExecutor" and try to get the correct Method in different environment with different Guava version.