### PR TITLE
fix: LIME sometimes return NaN weights

### DIFF
--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/LIMEBase.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/LIMEBase.scala
@@ -100,12 +100,9 @@ abstract class LIMEBase(override val uid: String)
             (input, output, weight)
         }.toSeq.unzip3
 
-        val inputsBV = BDM(inputs: _*)
-        val outputsBV = BDM(outputs: _*)
-        val weightsBV = BDV(weights: _*)
-
-        val lassoResults = outputsBV(::, *).toIndexedSeq.map {
-          new LassoRegression(regularization).fit(inputsBV, _, weightsBV, fitIntercept = true)
+        val (inputsBM, outputsBM, weightsBV) = (BDM(inputs: _*), BDM(outputs: _*), BDV(weights: _*))
+        val lassoResults = outputsBM(::, *).toIndexedSeq.map {
+          new LassoRegression(regularization).fit(inputsBM, _, weightsBV, fitIntercept = true)
         }
 
         val coefficientsMatrix = lassoResults.map(_.coefficients.toSpark)

--- a/core/src/main/scala/com/microsoft/ml/spark/explainers/Sampler.scala
+++ b/core/src/main/scala/com/microsoft/ml/spark/explainers/Sampler.scala
@@ -142,6 +142,21 @@ private[explainers] class LIMETabularSampler(val instance: Row, val featureStats
     (newSample, Vectors.dense(newStates.toArray), distance)
   }
 
+  /**
+   * Create a sample that's identical to the instance, with states set to 1 for categorical vars
+   * and original value for numerical vars. Distance is set to 0.
+   */
+  def sampleIdentity: (Row, Vector, Double) = {
+    val (identityRow, identityState) = featureStats.zipWithIndex.map {
+      case (_: DiscreteFeatureStats[Any], i) =>
+        (instance.get(i), 1d)
+      case (_: ContinuousFeatureStats, i) =>
+        (instance.getAsDouble(i), instance.getAsDouble(i))
+    }.unzip
+
+    (Row.fromSeq(identityRow), Vectors.dense(identityState.toArray), 0d)
+  }
+
   override def nextState: Vector = {
     val states = featureStats.zipWithIndex.map {
       case (feature: DiscreteFeatureStats[Any], i) =>


### PR DESCRIPTION
For categorical variables, if the LIME tabular sampler created samples that do not equal the original value for all simulated samples, we end up with an all zero variable, causing NaN weights. The fix is to simply append the original row as an identity sample to the simulated samples, making sure we don't end up with an all zero variable.