### PR TITLE
fix: LIME returns NaN weight if a feature contains a single value

### DIFF
--- a/core/src/test/scala/com/microsoft/ml/spark/core/test/base/TestBase.scala
+++ b/core/src/test/scala/com/microsoft/ml/spark/core/test/base/TestBase.scala
@@ -242,7 +242,7 @@ abstract class TestBase extends FunSuite with BeforeAndAfterEachTestData with Be
     (a: BDV[T], b: Any) => {
       b match {
         case p: BDV[T @unchecked] =>
-          norm(a - p) < tol
+          a.length == p.length && norm(a - p) < tol
         case _ => false
       }
     }

--- a/core/src/test/scala/com/microsoft/ml/spark/explainers/split1/LassoRegressionSuite.scala
+++ b/core/src/test/scala/com/microsoft/ml/spark/explainers/split1/LassoRegressionSuite.scala
@@ -103,4 +103,14 @@ class LassoRegressionSuite extends TestBase {
       new LassoRegression(0.05d).fit(x, y, w, fitIntercept = true)
     }
   }
+
+  test("Lasso regression with single value variable") {
+    val a = BDM((1.0, 1.0), (2.0, 1.0), (3.0, 1.0), (4.0, 1.0))
+    val b = BDV(2.0, 3.0, 4.0, 5.0)
+    val result = new LassoRegression(0d).fit(a, b, fitIntercept = true)
+    assert(result.coefficients === BDV(1.0, 0), "coefficients disagreed")
+    assert(result.intercept === 1d, "intercept disagreed")
+    assert(result.rSquared === 1d, "rSquared disagreed")
+    assert(result.loss === 0d, "loss disagreed")
+  }
 }


### PR DESCRIPTION
fix: LIME returns NaN weight if a feature contains a single value or when the sampler cannot obtain a different state for a feature due to data skew. It returns zero weights for all other features.