### PR TITLE
refactor: Rename Read to ReadImage

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/ml/spark/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/ml/spark/cognitive/ComputerVision.scala
@@ -329,7 +329,7 @@ class RecognizeText(override val uid: String)
   override protected def responseDataType: DataType = RTResponse.schema
 }
 
-object Read extends ComplexParamsReadable[Read] {
+object ReadImage extends ComplexParamsReadable[ReadImage] {
   def flatten(inputCol: String, outputCol: String): UDFTransformer = {
     val fromRow = ReadResponse.makeFromRowConverter
     new UDFTransformer()
@@ -344,14 +344,14 @@ object Read extends ComplexParamsReadable[Read] {
   }
 }
 
-class Read(override val uid: String)
+class ReadImage(override val uid: String)
   extends CognitiveServicesBaseNoHandler(uid)
     with BasicAsyncReply
     with HasImageInput with HasCognitiveServiceInput
     with HasInternalJsonOutputParser with HasSetLocation with BasicLogging with HasSetLinkedService {
   logClass()
 
-  def this() = this(Identifiable.randomUID("Read"))
+  def this() = this(Identifiable.randomUID("ReadImage"))
 
   val language = new ServiceParam[String](this, "language",
     "IThe BCP-47 language code of the text in the document. Currently," +

--- a/cognitive/src/test/scala/com/microsoft/ml/spark/cognitive/split1/ComputerVisionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/ml/spark/cognitive/split1/ComputerVisionSuite.scala
@@ -237,17 +237,17 @@ class RecognizeTextSuite extends TransformerFuzzing[RecognizeText]
   override def reader: MLReadable[_] = RecognizeText
 }
 
-class ReadSuite extends TransformerFuzzing[Read]
+class ReadImageSuite extends TransformerFuzzing[ReadImage]
   with CognitiveKey with Flaky with OCRUtils {
 
-  lazy val read: Read = new Read()
+  lazy val readImage: ReadImage = new ReadImage()
     .setSubscriptionKey(cognitiveKey)
     .setLocation("eastus")
     .setImageUrlCol("url")
     .setOutputCol("ocr")
     .setConcurrency(5)
 
-  lazy val bytesRead: Read = new Read()
+  lazy val bytesReadImage: ReadImage = new ReadImage()
     .setSubscriptionKey(cognitiveKey)
     .setLocation("eastus")
     .setImageBytesCol("imageBytes")
@@ -262,7 +262,7 @@ class ReadSuite extends TransformerFuzzing[Read]
   }
 
   test("Basic Usage with URL") {
-    val results = df.mlTransform(read, Read.flatten("ocr", "ocr"))
+    val results = df.mlTransform(readImage, ReadImage.flatten("ocr", "ocr"))
       .select("ocr")
       .collect()
     val headStr = results.head.getString(0)
@@ -271,7 +271,7 @@ class ReadSuite extends TransformerFuzzing[Read]
   }
 
   test("Basic Usage with pdf") {
-    val results = pdfDf.mlTransform(read, Read.flatten("ocr", "ocr"))
+    val results = pdfDf.mlTransform(readImage, ReadImage.flatten("ocr", "ocr"))
       .select("ocr")
       .collect()
     val headStr = results.head.getString(0)
@@ -282,7 +282,7 @@ class ReadSuite extends TransformerFuzzing[Read]
   }
 
   test("Basic Usage with Bytes") {
-    val results = bytesDF.mlTransform(bytesRead, Read.flatten("ocr", "ocr"))
+    val results = bytesDF.mlTransform(bytesReadImage, ReadImage.flatten("ocr", "ocr"))
       .select("ocr")
       .collect()
     val headStr = results.head.getString(0)
@@ -290,10 +290,10 @@ class ReadSuite extends TransformerFuzzing[Read]
       headStr === "CLOSED WHEN ONE DOOR CLOSES, ANOTHER OPENS. ALL YOU HAVE TO DO IS WALK IN")
   }
 
-  override def testObjects(): Seq[TestObject[Read]] =
-    Seq(new TestObject(read, df))
+  override def testObjects(): Seq[TestObject[ReadImage]] =
+    Seq(new TestObject(readImage, df))
 
-  override def reader: MLReadable[_] = Read
+  override def reader: MLReadable[_] = ReadImage
 }
 
 class RecognizeDomainSpecificContentSuite extends TransformerFuzzing[RecognizeDomainSpecificContent]


### PR DESCRIPTION
To avoid possible name duplicates with .NET MLReadable functions, rename Read class to ReadImage class.