### PR TITLE
Security upgrade required for openjdk from 8-alpine to 17-ea-22-jdk-oracle

### DIFF
--- a/tools/helm/spark/Dockerfile
+++ b/tools/helm/spark/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-slim-buster
+FROM openjdk:17-ea-22-jdk-oracle
 LABEL maintainer="Dalitso Banda dalitsohb@gmail.com"
 
 # Get Spark from US Apache mirror.

--- a/tools/helm/spark/mini.Dockerfile
+++ b/tools/helm/spark/mini.Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-alpine
+FROM openjdk:17-ea-22-jdk-oracle
 
 ARG spark_jars=jars
 ARG img_path=kubernetes/dockerfiles


### PR DESCRIPTION
Security upgrade required for openjdk from 8-alpine to 17-ea-22-jdk-oracle